### PR TITLE
PSR-2 compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 coverage
 coverage.xml
+/.php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "~4.1",
+        "fabpot/php-cs-fixer": "2.0.*@dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -5,25 +5,25 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class Extractor implements ExtractorInterface
-    {
+{
     /** @var Syntax */
     private $syntax;
 
     public function __construct(Syntax $syntax = null)
-        {
+    {
         $this->syntax = $syntax ?: new Syntax();
-        }
+    }
 
     /**
      * @param string $text
      * @return Match[]
      */
     public function extract($text)
-        {
+    {
         preg_match_all($this->syntax->getShortcodeRegex(), $text, $matches, PREG_OFFSET_CAPTURE);
 
-        return array_map(function(array $matches) {
+        return array_map(function (array $matches) {
             return new Match($matches[1], $matches[0]);
             }, $matches[0]);
-        }
     }
+}

--- a/src/ExtractorInterface.php
+++ b/src/ExtractorInterface.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 interface ExtractorInterface
-    {
+{
     /**
      * Extract shortcode string matches with their offsets for further analysis
      *
@@ -14,4 +14,4 @@ interface ExtractorInterface
      * @return Match[]
      */
     public function extract($text);
-    }
+}

--- a/src/HandlerInterface.php
+++ b/src/HandlerInterface.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 interface HandlerInterface
-    {
+{
     /**
      * Checks if shortcode contains enough and valid data to be processed
      *
@@ -23,4 +23,4 @@ interface HandlerInterface
      * @return string
      */
     public function handle(Shortcode $shortcode);
-    }
+}

--- a/src/Match.php
+++ b/src/Match.php
@@ -5,28 +5,28 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class Match
-    {
+{
     private $position;
     private $string;
 
     public function __construct($position, $string)
-        {
+    {
         $this->position = $position;
         $this->string = $string;
-        }
+    }
 
     public function getLength()
-        {
+    {
         return mb_strlen($this->string);
-        }
+    }
 
     public function getPosition()
-        {
+    {
         return $this->position;
-        }
+    }
 
     public function getString()
-        {
+    {
         return $this->string;
-        }
     }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -5,63 +5,61 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class Parser implements ParserInterface
-    {
+{
     /** @var Syntax */
     private $syntax;
 
     public function __construct(Syntax $syntax = null)
-        {
+    {
         $this->syntax = $syntax ?: new Syntax();
-        }
+    }
 
     public function parse($text)
-        {
+    {
         $count = preg_match($this->syntax->getSingleShortcodeRegex(), $text, $matches);
 
-        if(!$count)
-            {
+        if (!$count) {
             $msg = 'Failed to match single shortcode in text "%s"!';
             throw new \RuntimeException(sprintf($msg, $text));
-            }
+        }
 
         return new Shortcode(
             $matches[2],
             isset($matches[3]) ? $this->parseParameters($matches[3]) : array(),
             isset($matches[4]) ? $matches[4] : null
             );
-        }
+    }
 
     private function parseParameters($text)
-        {
+    {
         preg_match_all($this->syntax->getArgumentsRegex(), $text, $argsMatches);
 
         $return = array();
-        foreach($argsMatches[1] as $item)
-            {
+        foreach ($argsMatches[1] as $item) {
             $parts = explode($this->syntax->getParameterValueSeparator(), $item, 2);
             $return[$parts[0]] = $this->parseValue(isset($parts[1]) ? $parts[1] : null);
-            }
-
-        return $return;
         }
 
+        return $return;
+    }
+
     private function parseValue($value)
-        {
+    {
         return $this->isStringValue($value)
             ? $this->extractStringValue($value)
             : $value;
-        }
+    }
 
     private function extractStringValue($value)
-        {
+    {
         $length = strlen($this->syntax->getParameterValueDelimiter());
 
         return substr($value, $length, -1 * $length);
-        }
+    }
 
     private function isStringValue($value)
-        {
+    {
         return preg_match('/^'.$this->syntax->getParameterValueDelimiter().'/us', $value)
             && preg_match('/'.$this->syntax->getParameterValueDelimiter().'$/us', $value);
-        }
     }
+}

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 interface ParserInterface
-    {
+{
     /**
      * Parse single shortcode match into object
      *
@@ -14,4 +14,4 @@ interface ParserInterface
      * @return Shortcode
      */
     public function parse($text);
-    }
+}

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class Processor implements ProcessorInterface
-    {
+{
     private $handlers = array();
     private $extractor;
     private $parser;
@@ -14,10 +14,10 @@ final class Processor implements ProcessorInterface
     private $maxIterations = 1;
 
     public function __construct(ExtractorInterface $extractor, ParserInterface $parser)
-        {
+    {
         $this->extractor = $extractor;
         $this->parser = $parser;
-        }
+    }
 
     /**
      * Registers handler for given shortcode name.
@@ -28,28 +28,26 @@ final class Processor implements ProcessorInterface
      * @return self
      */
     public function addHandler($name, $handler)
-        {
+    {
         $this->guardHandler($handler);
 
-        if(!$name || $this->hasHandler($name))
-            {
+        if (!$name || $this->hasHandler($name)) {
             $msg = 'Invalid name or duplicate shortcode handler for %s!';
             throw new \RuntimeException(sprintf($msg, $name));
-            }
+        }
 
         $this->handlers[$name] = $handler;
 
         return $this;
-        }
+    }
 
     private function guardHandler($handler)
-        {
-        if(!is_callable($handler) && !$handler instanceof HandlerInterface)
-            {
+    {
+        if (!is_callable($handler) && !$handler instanceof HandlerInterface) {
             $msg = 'Shortcode handler must be callable or implement HandlerInterface!';
             throw new \RuntimeException(sprintf($msg));
-            }
         }
+    }
 
     /**
      * Registers handler alias for given shortcode name, which means that
@@ -61,15 +59,15 @@ final class Processor implements ProcessorInterface
      * @return self
      */
     public function addHandlerAlias($alias, $name)
-        {
+    {
         $handler = $this->getHandler($name);
 
-        $this->addHandler($alias, function(Shortcode $shortcode) use($handler) {
+        $this->addHandler($alias, function (Shortcode $shortcode) use ($handler) {
             return call_user_func_array($handler, array($shortcode));
             });
 
         return $this;
-        }
+    }
 
     /**
      * Default library behavior is to ignore and return matches of shortcodes
@@ -79,11 +77,11 @@ final class Processor implements ProcessorInterface
      * @param callable|HandlerInterface $handler Handler for shortcodes without registered name handler
      */
     public function setDefaultHandler($handler)
-        {
+    {
         $this->guardHandler($handler);
 
         $this->defaultHandler = $handler;
-        }
+    }
 
     /**
      * Entry point for shortcode processing. Implements iterative algorithm for
@@ -94,21 +92,19 @@ final class Processor implements ProcessorInterface
      * @return string
      */
     public function process($text)
-        {
+    {
         $iterations = $this->maxIterations === null ? 1 : $this->maxIterations;
-        while($iterations--)
-            {
+        while ($iterations--) {
             $newText = $this->processIteration($text, 0);
-            if($newText === $text)
-                {
+            if ($newText === $text) {
                 break;
-                }
+            }
             $text = $newText;
             $iterations += $this->maxIterations === null ? 1 : 0;
-            }
+        }
 
         return $text;
-        }
+    }
 
     /**
      * Expects matches sorted by position returned from Extractor. Matches are
@@ -121,31 +117,28 @@ final class Processor implements ProcessorInterface
      * @return string
      */
     private function processIteration($text, $level)
-        {
-        if(null !== $this->recursionDepth && $level > $this->recursionDepth)
-            {
+    {
+        if (null !== $this->recursionDepth && $level > $this->recursionDepth) {
             return $text;
-            }
+        }
 
         /** @var $matches Match[] */
         $matches = array_reverse($this->extractor->extract($text));
-        foreach($matches as $match)
-            {
+        foreach ($matches as $match) {
             $shortcode = $this->parser->parse($match->getString());
             $content = $shortcode->hasContent()
                 ? $this->processIteration($shortcode->getContent(), $level + 1)
                 : $shortcode->getContent();
             $shortcode = new Shortcode($shortcode->getName(), $shortcode->getParameters(), $content);
             $handler = $this->getHandler($shortcode->getName());
-            if($handler)
-                {
+            if ($handler) {
                 $replace = $this->callHandler($handler, $shortcode, $match);
                 $text = substr_replace($text, $replace, $match->getPosition(), $match->getLength());
-                }
             }
+        }
 
         return $text;
-        }
+    }
 
     /**
      * Recursion depth level, null means infinite, any integer greater than or
@@ -156,17 +149,16 @@ final class Processor implements ProcessorInterface
      * @return self
      */
     public function setRecursionDepth($depth)
-        {
-        if(null !== $depth && !(is_int($depth) && $depth >= 0))
-            {
+    {
+        if (null !== $depth && !(is_int($depth) && $depth >= 0)) {
             $msg = 'Recursion depth must be null (infinite) or integer >= 0!';
             throw new \InvalidArgumentException($msg);
-            }
+        }
 
         $this->recursionDepth = $depth;
 
         return $this;
-        }
+    }
 
     /**
      * Maximum number of iterations, null means infinite, any integer greater
@@ -177,17 +169,16 @@ final class Processor implements ProcessorInterface
      * @return self
      */
     public function setMaxIterations($iterations)
-        {
-        if(null !== $iterations && !(is_int($iterations) && $iterations >= 0))
-            {
+    {
+        if (null !== $iterations && !(is_int($iterations) && $iterations >= 0)) {
             $msg = 'Maximum number of iterations must be null (infinite) or integer >= 0!';
             throw new \InvalidArgumentException($msg);
-            }
+        }
 
         $this->maxIterations = $iterations;
 
         return $this;
-        }
+    }
 
     /**
      * @deprecated Use self::setRecursionDepth() instead
@@ -197,31 +188,30 @@ final class Processor implements ProcessorInterface
      * @return self
      */
     public function setRecursion($recursion)
-        {
+    {
         return $this->setRecursionDepth($recursion ? null : 0);
-        }
+    }
 
     private function callHandler($handler, Shortcode $shortcode, Match $match)
-        {
-        if($handler instanceof HandlerInterface)
-            {
+    {
+        if ($handler instanceof HandlerInterface) {
             return $handler->isValid($shortcode)
                 ? $handler->handle($shortcode)
                 : $match->getString();
-            }
-
-        return call_user_func_array($handler, array($shortcode));
         }
 
+        return call_user_func_array($handler, array($shortcode));
+    }
+
     private function getHandler($name)
-        {
+    {
         return $this->hasHandler($name)
             ? $this->handlers[$name]
             : ($this->defaultHandler ? $this->defaultHandler : null);
-        }
+    }
 
     private function hasHandler($name)
-        {
+    {
         return array_key_exists($name, $this->handlers);
-        }
     }
+}

--- a/src/ProcessorInterface.php
+++ b/src/ProcessorInterface.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 interface ProcessorInterface
-    {
+{
     /**
      * Register shortcode callback handler
      *
@@ -24,4 +24,4 @@ interface ProcessorInterface
      * @return string
      */
     public function process($text);
-    }
+}

--- a/src/Serializer/JsonSerializer.php
+++ b/src/Serializer/JsonSerializer.php
@@ -5,29 +5,27 @@ use Thunder\Shortcode\SerializerInterface;
 use Thunder\Shortcode\Shortcode;
 
 final class JsonSerializer implements SerializerInterface
-    {
+{
     public function serialize(Shortcode $s)
-        {
+    {
         return json_encode(array(
             'name' => $s->getName(),
             'parameters' => $s->getParameters(),
             'content' => $s->getContent(),
             ));
-        }
+    }
 
     public function unserialize($text)
-        {
+    {
         $data = json_decode($text, true);
 
-        if(!is_array($data))
-            {
+        if (!is_array($data)) {
             throw new \RuntimeException('Invalid JSON, cannot unserialize Shortcode!');
-            }
-        if(!array_diff_key($data, array('name', 'parameters', 'content')))
-            {
+        }
+        if (!array_diff_key($data, array('name', 'parameters', 'content'))) {
             throw new \RuntimeException('Malformed Shortcode JSON, expected name, parameters, and content!');
-            }
+        }
 
         return new Shortcode($data['name'], $data['parameters'], $data['content']);
-        }
     }
+}

--- a/src/Serializer/TextSerializer.php
+++ b/src/Serializer/TextSerializer.php
@@ -7,16 +7,16 @@ use Thunder\Shortcode\Shortcode;
 use Thunder\Shortcode\Syntax;
 
 final class TextSerializer implements SerializerInterface
-    {
+{
     private $syntax;
 
     public function __construct(Syntax $syntax = null)
-        {
+    {
         $this->syntax = $syntax ?: new Syntax();
-        }
+    }
 
     public function serialize(Shortcode $s)
-        {
+    {
         $open = $this->syntax->getOpeningTag();
         $close = $this->syntax->getClosingTag();
         $marker = $this->syntax->getClosingTagMarker();
@@ -24,38 +24,35 @@ final class TextSerializer implements SerializerInterface
         $parameters = $this->serializeParameters($s->getParameters());
         $return = $open.$s->getName().$parameters.$close;
 
-        if(null !== $s->getContent())
-            {
+        if (null !== $s->getContent()) {
             $return .= $s->getContent().$open.$marker.$s->getName().$close;
-            }
-
-        return $return;
         }
 
+        return $return;
+    }
+
     private function serializeParameters(array $parameters)
-        {
+    {
         $return = '';
-        foreach($parameters as $key => $value)
-            {
+        foreach ($parameters as $key => $value) {
             $return .= ' '.$key;
-            if(null !== $value)
-                {
+            if (null !== $value) {
                 $delimiter = $this->syntax->getParameterValueDelimiter();
                 $separator = $this->syntax->getParameterValueSeparator();
 
                 $return .= $separator.(preg_match('/^\w+$/us', $value)
                     ? $value
                     : $delimiter.$value.$delimiter);
-                }
             }
-
-        return $return;
         }
 
+        return $return;
+    }
+
     public function unserialize($text)
-        {
+    {
         $parser = new Parser();
 
         return $parser->parse($text);
-        }
     }
+}

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 interface SerializerInterface
-    {
+{
     /**
      * Serializes Shortcode class instance into given format
      *
@@ -23,4 +23,4 @@ interface SerializerInterface
      * @return Shortcode
      */
     public function unserialize($text);
-    }
+}

--- a/src/Shortcode.php
+++ b/src/Shortcode.php
@@ -5,42 +5,42 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class Shortcode
-    {
+{
     private $name;
     private $parameters;
     private $content;
 
     public function __construct($name, array $arguments, $content)
-        {
+    {
         $this->name = $name;
         $this->parameters = $arguments;
         $this->content = $content;
-        }
+    }
 
     public function hasContent()
-        {
+    {
         return $this->content !== null;
-        }
+    }
 
     public function getName()
-        {
+    {
         return $this->name;
-        }
+    }
 
     public function getParameters()
-        {
+    {
         return $this->parameters;
-        }
+    }
 
     public function hasParameter($name)
-        {
+    {
         return array_key_exists($name, $this->parameters);
-        }
+    }
 
     public function hasParameters()
-        {
+    {
         return (bool)$this->parameters;
-        }
+    }
 
     /**
      * Returns parameter value using its name, throws exception when there was
@@ -54,19 +54,17 @@ final class Shortcode
      * @return null
      */
     public function getParameter($name, $default = null)
-        {
-        if($this->hasParameter($name))
-            {
+    {
+        if ($this->hasParameter($name)) {
             return $this->parameters[$name];
-            }
-        if(null !== $default)
-            {
+        }
+        if (null !== $default) {
             return $default;
-            }
+        }
 
         $msg = 'Shortcode parameter %s not found and no default value was set!';
         throw new \RuntimeException(sprintf($msg, $name));
-        }
+    }
 
     /**
      * Returns name for position-based parameter, null if there was no parameter
@@ -77,11 +75,11 @@ final class Shortcode
      * @return string|null
      */
     public function getParameterAt($index)
-        {
+    {
         $keys = array_keys($this->parameters);
 
         return array_key_exists($index, $keys) ? $keys[$index] : null;
-        }
+    }
 
     /**
      * Returns shortcode content (data between opening and closing tag). Returns
@@ -90,7 +88,7 @@ final class Shortcode
      * @return string|null
      */
     public function getContent()
-        {
+    {
         return $this->content;
-        }
     }
+}

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class Syntax
-    {
+{
     private $openingTag;
     private $closingTag;
     private $closingTagMarker;
@@ -14,70 +14,70 @@ final class Syntax
 
     public function __construct($openingTag = null, $closingTag = null, $closingTagMarker = null,
                                 $parameterValueSeparator = null, $parameterValueDelimiter = null)
-        {
+    {
         $this->openingTag = $openingTag ?: '[';
         $this->closingTag = $closingTag ?: ']';
         $this->closingTagMarker = $closingTagMarker ?: '/';
         $this->parameterValueSeparator = $parameterValueSeparator ?: '=';
         $this->parameterValueDelimiter = $parameterValueDelimiter ?: '"';
-        }
+    }
 
     public function getShortcodeRegex()
-        {
+    {
         return '~'.$this->createShortcodeRegex().'~us';
-        }
+    }
 
     public function getSingleShortcodeRegex()
-        {
+    {
         return '~^'.$this->createShortcodeRegex().'$~us';
-        }
+    }
 
     public function getArgumentsRegex()
-        {
+    {
         $equals = $this->quote($this->getParameterValueSeparator());
         $string = $this->quote($this->getParameterValueDelimiter());
 
         return '~(?:\s+(\w+(?:(?=\s|$)|'.$equals.'\w+|'.$equals.$string.'([^'.$string.'\\\\]*(?:\\\\.[^'.$string.'\\\\]*)*?)'.$string.')))~us';
-        }
+    }
 
     private function createShortcodeRegex()
-        {
+    {
         $open = $this->quote($this->getOpeningTag());
         $slash = $this->quote($this->getClosingTagMarker());
         $close = $this->quote($this->getClosingTag());
 
         return '('.$open.'([\w-]+)(\s+.+?)?'.$close.'(?:(.*?)'.$open.$slash.'(\2)'.$close.')?)';
-        }
+    }
 
     private function quote($text)
-        {
+    {
         return preg_replace('/(.)/us', '\\\\$0', $text);
-        }
+    }
 
     /* --- GETTERS --- */
 
     public function getOpeningTag()
-        {
+    {
         return $this->openingTag;
-        }
+    }
 
     public function getClosingTag()
-        {
+    {
         return $this->closingTag;
-        }
+    }
 
     public function getClosingTagMarker()
-        {
+    {
         return $this->closingTagMarker;
-        }
+    }
 
     public function getParameterValueSeparator()
-        {
+    {
         return $this->parameterValueSeparator;
-        }
+    }
 
     public function getParameterValueDelimiter()
-        {
+    {
         return $this->parameterValueDelimiter;
-        }
     }
+}

--- a/src/SyntaxBuilder.php
+++ b/src/SyntaxBuilder.php
@@ -5,7 +5,7 @@ namespace Thunder\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class SyntaxBuilder
-    {
+{
     private $openingTag;
     private $closingTag;
     private $closingTagMarker;
@@ -13,49 +13,49 @@ final class SyntaxBuilder
     private $parameterValueDelimiter;
 
     public function __construct()
-        {
-        }
+    {
+    }
 
     public function getSyntax()
-        {
+    {
         return new Syntax(
             $this->openingTag, $this->closingTag, $this->closingTagMarker,
             $this->parameterValueSeparator, $this->parameterValueDelimiter
             );
-        }
+    }
 
     public function setOpeningTag($tag)
-        {
+    {
         $this->openingTag = $tag;
 
         return $this;
-        }
+    }
 
     public function setClosingTag($tag)
-        {
+    {
         $this->closingTag = $tag;
 
         return $this;
-        }
+    }
 
     public function setClosingTagMarker($marker)
-        {
+    {
         $this->closingTagMarker = $marker;
 
         return $this;
-        }
+    }
 
     public function setParameterValueSeparator($separator)
-        {
+    {
         $this->parameterValueSeparator = $separator;
 
         return $this;
-        }
+    }
 
     public function setParameterValueDelimiter($delimiter)
-        {
+    {
         $this->parameterValueDelimiter = $delimiter;
 
         return $this;
-        }
     }
+}

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -9,7 +9,7 @@ use Thunder\Shortcode\Syntax;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class ExtractorTest extends \PHPUnit_Framework_TestCase
-    {
+{
     /**
      * @param string $text
      * @param Match[] $matches
@@ -17,21 +17,20 @@ final class ExtractorTest extends \PHPUnit_Framework_TestCase
      * @dataProvider provideTexts
      */
     public function testShortcode($text, array $matches)
-        {
+    {
         $extractor = new Extractor();
         $foundMatches = $extractor->extract($text);
 
         $matchesCount = count($matches);
         $this->assertSame($matchesCount, count($foundMatches));
-        for($i = 0; $i < $matchesCount; $i++)
-            {
+        for ($i = 0; $i < $matchesCount; $i++) {
             $this->assertSame($matches[$i]->getPosition(), $foundMatches[$i]->getPosition());
             $this->assertSame($matches[$i]->getString(), $foundMatches[$i]->getString());
-            }
         }
+    }
 
     public function provideTexts()
-        {
+    {
         return array(
             array('Lorem [ipsum] random [code-code arg=val] which is here', array(
                 new Match(6, '[ipsum]'),
@@ -50,10 +49,10 @@ final class ExtractorTest extends \PHPUnit_Framework_TestCase
                 new Match(27, '[x x y=z a="b c"]a[/x]'),
                 )),
             );
-        }
+    }
 
     public function testWithDifferentSyntax()
-        {
+    {
         $extractor = new Extractor(new Syntax('[[', ']]', '//', '==', '""'));
 
         $matches = $extractor->extract('so[[m]]ething [[code]] othe[[r]]various[[//r]]');
@@ -62,5 +61,5 @@ final class ExtractorTest extends \PHPUnit_Framework_TestCase
 
         $matches = $extractor->extract('x [[code arg==""val oth""]]cont[[//code]] y');
         $this->assertCount(1, $matches);
-        }
     }
+}

--- a/tests/Fake/HtmlShortcode.php
+++ b/tests/Fake/HtmlShortcode.php
@@ -5,16 +5,16 @@ use Thunder\Shortcode\HandlerInterface;
 use Thunder\Shortcode\Shortcode;
 
 class HtmlShortcode implements HandlerInterface
-    {
+{
     public function isValid(Shortcode $s)
-        {
+    {
         return $s->hasParameters();
-        }
+    }
 
     public function handle(Shortcode $s)
-        {
+    {
         $tag = $s->getParameterAt(0);
 
         return '<'.$tag.'>'.$s->getContent().'</'.$tag.'>';
-        }
     }
+}

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -1,18 +1,19 @@
 <?php
 namespace Thunder\Shortcode\Tests;
+
 use Thunder\Shortcode\Match;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class MatchTest extends \PHPUnit_Framework_TestCase
-    {
+{
     public function testMatch()
-        {
+    {
         $match = new Match(4, 'match');
 
         $this->assertSame(4, $match->getPosition());
         $this->assertSame('match', $match->getString());
         $this->assertSame(5, $match->getLength());
-        }
     }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -8,22 +8,22 @@ use Thunder\Shortcode\Syntax;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class ParserTest extends \PHPUnit_Framework_TestCase
-    {
+{
     /**
      * @dataProvider provideShortcodes
      */
     public function testParser($code, $name, array $args, $content)
-        {
+    {
         $parser = new Parser();
         $shortcode = $parser->parse($code);
 
         $this->assertSame($name, $shortcode->getName());
         $this->assertSame($args, $shortcode->getParameters());
         $this->assertSame($content, $shortcode->getContent());
-        }
+    }
 
     public function provideShortcodes()
-        {
+    {
         return array(
             array('[sc]', 'sc', array(), null),
             array('[sc]', 'sc', array(), null),
@@ -36,17 +36,17 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[sc a="x y" b="x" c=""]', 'sc', array('a' => 'x y', 'b' => 'x', 'c' => ''), null),
             array('[sc a="a \"\" b"]', 'sc', array('a' => 'a \"\" b'), null),
             );
-        }
+    }
 
     public function testExceptionInvalidShortcode()
-        {
+    {
         $parser = new Parser();
         $this->setExpectedException('RuntimeException');
         $parser->parse('');
-        }
+    }
 
     public function testWithDifferentSyntax()
-        {
+    {
         $parser = new Parser(new Syntax('[[', ']]', '//', '==', '""'));
 
         $shortcode = $parser->parse('[[code arg==""val oth""]]cont[[//code]]');
@@ -54,15 +54,15 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $shortcode->getParameters());
         $this->assertSame('val oth', $shortcode->getParameter('arg'));
         $this->assertSame('cont', $shortcode->getContent());
-        }
+    }
 
     public function testDifferentSyntaxEscapedQuotes()
-        {
+    {
         $parser = new Parser(new Syntax('^', '$', '&', '!!!', '@@'));
         $shortcode = $parser->parse('^code a!!!@@\"\"@@ b!!!@@x\"y@@ c$cnt^&code$');
 
         $this->assertSame('code', $shortcode->getName());
         $this->assertSame(array('a' => '\\"\\"', 'b' => 'x\"y', 'c' => null), $shortcode->getParameters());
         $this->assertSame('cnt', $shortcode->getContent());
-        }
     }
+}

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -11,33 +11,33 @@ use Thunder\Shortcode\Tests\Fake\HtmlShortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class ProcessorTest extends \PHPUnit_Framework_TestCase
-    {
+{
     private function getProcessor()
-        {
+    {
         $processor = new Processor(new Extractor(), new Parser());
 
         $processor
-            ->addHandler('name', function(Shortcode $s) { return $s->getName(); })
-            ->addHandler('content', function(Shortcode $s) { return $s->getContent(); })
+            ->addHandler('name', function (Shortcode $s) { return $s->getName(); })
+            ->addHandler('content', function (Shortcode $s) { return $s->getContent(); })
             ->addHandler('html', new HtmlShortcode())
             ->addHandlerAlias('c', 'content')
             ->addHandlerAlias('n', 'name');
 
         return $processor;
-        }
+    }
 
     /**
      * @dataProvider provideTexts
      */
     public function testProcessor($text, $result)
-        {
+    {
         $processor = $this->getProcessor();
 
         $this->assertSame($result, $processor->process($text));
-        }
+    }
 
     public function provideTexts()
-        {
+    {
         return array(
             array('[name]', 'name'),
             array('[content]random[/content]', 'random'),
@@ -51,20 +51,20 @@ final class ProcessorTest extends \PHPUnit_Framework_TestCase
             array('x [html b]bold[/html] y [html code]code[/html] z', 'x <b>bold</b> y <code>code</code> z'),
             array('x [html]bold[/html] z', 'x [html]bold[/html] z'),
             );
-        }
+    }
 
     public function testProcessorWithoutRecursion()
-        {
+    {
         $processor = $this
             ->getProcessor()
             ->setRecursion(false);
 
         $result = $processor->process('x [content]a-[name][/name]-b[/content] y');
         $this->assertSame('x a-[name][/name]-b y', $result);
-        }
+    }
 
     public function testProcessorIterative()
-        {
+    {
         $processor = $this
             ->getProcessor()
             ->addHandlerAlias('d', 'c')
@@ -78,55 +78,55 @@ final class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         $processor->setMaxIterations(null);
         $this->assertSame('x abcde y', $processor->process('x [c]a[d]b[e]c[/e]d[/d]e[/c] y'));
-        }
+    }
 
     public function testExceptionOnInvalidHandler()
-        {
+    {
         $processor = $this->getProcessor();
         $this->setExpectedException('RuntimeException');
         $processor->addHandler('invalid', new \stdClass());
-        }
+    }
 
     public function testExceptionOnDuplicateHandler()
-        {
+    {
         $processor = $this->getProcessor();
         $this->setExpectedException('RuntimeException');
-        $processor->addHandler('name', function() {});
-        }
+        $processor->addHandler('name', function () {});
+    }
 
     public function testDefaultHandler()
-        {
+    {
         $processor = $this->getProcessor();
-        $processor->setDefaultHandler(function(Shortcode $s) { return $s->getName(); });
+        $processor->setDefaultHandler(function (Shortcode $s) { return $s->getName(); });
 
         $this->assertSame('namerandom', $processor->process('[name][other][/name][random]'));
-        }
+    }
 
     public function testExceptionOnInvalidRecursionDepth()
-        {
+    {
         $processor = $this->getProcessor();
         $this->setExpectedException('InvalidArgumentException');
         $processor->setRecursionDepth(new \stdClass());
-        }
+    }
 
     public function testExceptionOnInvalidMaxIterations()
-        {
+    {
         $processor = $this->getProcessor();
         $this->setExpectedException('InvalidArgumentException');
         $processor->setMaxIterations(new \stdClass());
-        }
+    }
 
     public function testPreventInfiniteLoop()
-        {
+    {
         $processor = $this
             ->getProcessor()
-            ->addHandler('self', function() { return '[self]'; })
-            ->addHandler('other', function() { return '[self]'; })
-            ->addHandler('random', function() { return '[various]'; })
+            ->addHandler('self', function () { return '[self]'; })
+            ->addHandler('other', function () { return '[self]'; })
+            ->addHandler('random', function () { return '[various]'; })
             ->setMaxIterations(null);
 
         $processor->process('[self]');
         $processor->process('[other]');
         $processor->process('[random]');
-        }
     }
+}

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -10,12 +10,12 @@ use Thunder\Shortcode\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class SerializerTest extends \PHPUnit_Framework_TestCase
-    {
+{
     /**
      * @dataProvider provideShortcodes
      */
     public function testSerializer(SerializerInterface $serializer, $text, Shortcode $shortcode)
-        {
+    {
         $serialized = $serializer->serialize($shortcode);
         $this->assertSame($text, $serialized);
 
@@ -23,29 +23,29 @@ final class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($shortcode->getName(), $s->getName());
         $this->assertSame($shortcode->getParameters(), $s->getParameters());
         $this->assertSame($shortcode->getContent(), $s->getContent());
-        }
+    }
 
     public function provideShortcodes()
-        {
+    {
         return array(
             array(new TextSerializer(), '[x arg=val]', new Shortcode('x', array('arg' => 'val'), null)),
             array(new TextSerializer(), '[x arg=val]cnt[/x]', new Shortcode('x', array('arg' => 'val'), 'cnt')),
             array(new JsonSerializer(), '{"name":"x","parameters":{"arg":"val"},"content":"cnt"}',
                 new Shortcode('x', array('arg' => 'val'), 'cnt')),
             );
-        }
+    }
 
     public function testExceptionInvalidJson()
-        {
+    {
         $serializer = new JsonSerializer();
         $this->setExpectedException('RuntimeException');
         $serializer->unserialize('');
-        }
+    }
 
     public function testExceptionMalformedJson()
-        {
+    {
         $serializer = new JsonSerializer();
         $this->setExpectedException('RuntimeException');
         $serializer->unserialize('{}');
-        }
     }
+}

--- a/tests/ShortcodeTest.php
+++ b/tests/ShortcodeTest.php
@@ -8,12 +8,12 @@ use Thunder\Shortcode\Shortcode;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class ShortcodeTest extends \PHPUnit_Framework_TestCase
-    {
+{
     /**
      * @dataProvider provideShortcodes
      */
     public function testShortcode($expected, $name, array $args, $content)
-        {
+    {
         $s = new Shortcode($name, $args, $content);
         $textSerializer = new TextSerializer();
 
@@ -21,20 +21,20 @@ final class ShortcodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($args, $s->getParameters());
         $this->assertSame($content, $s->getContent());
         $this->assertSame($expected, $textSerializer->serialize($s));
-        }
+    }
 
     public function provideShortcodes()
-        {
+    {
         return array(
             array('[x arg=val]', 'x', array('arg' => 'val'), null),
             array('[x arg=val][/x]', 'x', array('arg' => 'val'), ''),
             array('[x arg=val]inner[/x]', 'x', array('arg' => 'val'), 'inner'),
             array('[x arg="val val"]inner[/x]', 'x', array('arg' => 'val val'), 'inner'),
             );
-        }
+    }
 
     public function testObject()
-        {
+    {
         $shortcode = new Shortcode('random', array(
             'arg' => 'value',
             'none' => null,
@@ -46,12 +46,12 @@ final class ShortcodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('value', $shortcode->getParameter('arg'));
         $this->assertSame('', $shortcode->getParameter('invalid', ''));
         $this->assertSame(42, $shortcode->getParameter('invalid', 42));
-        }
+    }
 
     public function testExceptionOnMissingParameterWithNoDefaultValue()
-        {
+    {
         $shortcode = new Shortcode('name', array(), null);
         $this->setExpectedException('RuntimeException');
         $shortcode->getParameter('invalid');
-        }
     }
+}

--- a/tests/SyntaxTest.php
+++ b/tests/SyntaxTest.php
@@ -8,9 +8,9 @@ use Thunder\Shortcode\SyntaxBuilder;
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 final class SyntaxTest extends \PHPUnit_Framework_TestCase
-    {
+{
     public function testSyntax()
-        {
+    {
         $syntax = new Syntax();
 
         $this->assertSame('[', $syntax->getOpeningTag());
@@ -18,10 +18,10 @@ final class SyntaxTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/', $syntax->getClosingTagMarker());
         $this->assertSame('=', $syntax->getParameterValueSeparator());
         $this->assertSame('"', $syntax->getParameterValueDelimiter());
-        }
+    }
 
     public function testCustomSyntax()
-        {
+    {
         $syntax = new Syntax('[[', ']]', '//', '==', '""');
 
         $this->assertSame('[[', $syntax->getOpeningTag());
@@ -29,10 +29,10 @@ final class SyntaxTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('//', $syntax->getClosingTagMarker());
         $this->assertSame('==', $syntax->getParameterValueSeparator());
         $this->assertSame('""', $syntax->getParameterValueDelimiter());
-        }
+    }
 
     public function testBuilder()
-        {
+    {
         $builder = new SyntaxBuilder();
         $syntax = $builder->getSyntax();
 
@@ -56,5 +56,5 @@ final class SyntaxTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('//', $syntax->getClosingTagMarker());
         $this->assertSame('==', $syntax->getParameterValueSeparator());
         $this->assertSame('""', $syntax->getParameterValueDelimiter());
-        }
     }
+}


### PR DESCRIPTION
This PR brings the library into [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) compliance. It's almost 100% whitespace changes made by the [PHP Coding Standards Fixer](http://cs.sensiolabs.org/). You can run the checker on your local repo with:

```
$ composer update
$ ./vendor/bin/php-cs-fixer fix .
```
