### PR TITLE
Whitespace tolerance

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -40,7 +40,7 @@ final class Parser implements ParserInterface
         $return = array();
         foreach($argsMatches[1] as $item)
             {
-            $parts = explode($this->syntax->getParameterValueSeparator(), $item, 2);
+            $parts = preg_split('~\s*' . $this->syntax->getParameterValueSeparator() . '\s*~', $item, 2);
             $return[$parts[0]] = $this->parseValue(isset($parts[1]) ? $parts[1] : null);
             }
 

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -11,6 +11,7 @@ final class Syntax
     private $closingTagMarker;
     private $parameterValueSeparator;
     private $parameterValueDelimiter;
+    private static $regexCache = array();
 
     public function __construct($openingTag = null, $closingTag = null, $closingTagMarker = null,
                                 $parameterValueSeparator = null, $parameterValueDelimiter = null)
@@ -35,38 +36,91 @@ final class Syntax
     public function getArgumentsRegex()
         {
         $equals = $this->quote($this->getParameterValueSeparator());
-        $string = $this->quote($this->getParameterValueDelimiter());
+        $quote = $this->quote($this->getParameterValueDelimiter());
+        $cacheKey = "arguments-$equals-$quote";
 
-        // lookahead test for either space or end of string
-        $empty = '(?=\s|$)';
-        // equals sign and alphanumeric value
-        $simple = $equals.'\w+';
-        // equals sign and value without unescaped string delimiters enclosed in them
-        $complex = $equals.$string.'([^'.$string.'\\\\]*(?:\\\\.[^'.$string.'\\\\]*)*?)'.$string;
+        if (!isset(self::$regexCache[$cacheKey])) {
 
-        return '~(?:\s+(\w+(?:'.$empty.'|'.$simple.'|'.$complex.')))~us';
+            $regex =
+                    '(?:' .
+                        '\s+' .
+                        '(' .
+                            '\w+' .
+                            '(?:' .
+                                '(?=\s|$)' .    // lookahead test for either space or end of string
+                                '|' .
+                                $equals .       // equals sign and alphanumeric value
+                                '\w+' .
+                                '|' .
+                                $equals .       // equals sign and value without unescaped string delimiters enclosed in them
+                                $quote .
+                                '(' .
+                                    '[^' .
+                                        $quote .
+                                        '\\\\' .
+                                    ']*' .
+                                    '(?:' .
+                                        '\\\\.' .
+                                        '[^' .
+                                            $quote .
+                                            '\\\\' .
+                                        ']*' .
+                                    ')*?' .
+                                ')' .
+                                $quote .
+                            ')' .
+                        ')' .
+                    ')';
+
+            self::$regexCache[$cacheKey] = "~$regex~us";
+        }
+
+        return self::$regexCache[$cacheKey];
         }
 
     private function createShortcodeRegex()
         {
-        $open = $this->quote($this->getOpeningTag());
-        $slash = $this->quote($this->getClosingTagMarker());
-        $close = $this->quote($this->getClosingTag());
+        $openingTag = $this->quote($this->getOpeningTag());
+        $closingTagMarker = $this->quote($this->getClosingTagMarker());
+        $closingTag = $this->quote($this->getClosingTag());
+        $cacheKey = "shortcode-$openingTag-$closingTagMarker-$closingTag";
 
-        // alphanumeric characters and dash
-        $name = '([\w-]+)';
-        // any characters that are not closing tag marker
-        $parameters = '(\s+[^'.$slash.']+?)?';
-        // non-greedy match for any characters
-        $content = '(.*?)';
+        if (!isset(self::$regexCache[$cacheKey])) {
 
-        // open tag, name, parameters, maybe some spaces, closing marker, closing tag
-        $selfClosed  = $open.$name.$parameters.'\s*'.$slash.$close;
-        // open tag, name, parameters, closing tag, maybe some content and closing
-        // block with backreference name validation
-        $withContent = $open.$name.$parameters.$close.'(?:'.$content.$open.$slash.'(\4)'.$close.')?';
+            // alphanumeric characters and dash
+            $name = '([\w-]+)';
+            // any characters that are not closing tag marker
+            $parameters = '(\s+[^'.$closingTagMarker.']+?)?';
+            // non-greedy match for any characters
+            $content = '(.*?)';
 
-        return '((?:'.$selfClosed.'|'.$withContent.'))';
+            self::$regexCache[$cacheKey] =
+
+                '(' .
+                    '(?:' .
+                        $openingTag .
+                        $name .
+                        $parameters .
+                        '\s*' .
+                        $closingTagMarker .
+                        $closingTag .
+                        '|' .
+                        $openingTag .
+                        $name .
+                        $parameters .
+                        $closingTag .
+                        '(?:' .
+                            $content .
+                            $openingTag .
+                            $closingTagMarker .
+                            '(\4)' .
+                            $closingTag .
+                        ')?' .
+                    ')' .
+                ')';
+        }
+
+        return self::$regexCache[$cacheKey];
         }
 
     private function quote($text)

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -41,13 +41,24 @@ final class Syntax
 
         if (!isset(self::$regexCache[$cacheKey])) {
 
+            $optionalWhitespace = '\s*';
+
+            $equals = $optionalWhitespace . $equals . $optionalWhitespace;
+
             $regex =
                     '(?:' .
                         '\s+' .
                         '(' .
                             '\w+' .
                             '(?:' .
-                                '(?=\s|$)' .    // lookahead test for either space or end of string
+                                '(?=' .
+                                    '\s+' .
+                                    '[^' .
+                                        $equals .
+                                    ']+' .
+                                    '|' .
+                                    '$' .
+                                ')' .
                                 '|' .
                                 $equals .       // equals sign and alphanumeric value
                                 '\w+' .

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -97,6 +97,7 @@ final class Syntax
             $optionalWhitespace = '\s*';
 
             $openingTag = $openingTag . $optionalWhitespace;
+            $closingTag = $optionalWhitespace . $closingTag;
 
             self::$regexCache[$cacheKey] =
 

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -21,6 +21,12 @@ final class Syntax
         $this->closingTagMarker = $closingTagMarker ?: '/';
         $this->parameterValueSeparator = $parameterValueSeparator ?: '=';
         $this->parameterValueDelimiter = $parameterValueDelimiter ?: '"';
+
+        $this->openingTag = trim($this->openingTag);
+        $this->closingTag = trim($this->closingTag);
+        $this->closingTagMarker = trim($this->closingTagMarker);
+        $this->parameterValueSeparator = trim($this->parameterValueSeparator);
+        $this->parameterValueDelimiter = trim($this->parameterValueDelimiter);
         }
 
     public function getShortcodeRegex()

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -94,6 +94,10 @@ final class Syntax
             // non-greedy match for any characters
             $content = '(.*?)';
 
+            $optionalWhitespace = '\s*';
+
+            $openingTag = $openingTag . $optionalWhitespace;
+
             self::$regexCache[$cacheKey] =
 
                 '(' .
@@ -101,7 +105,7 @@ final class Syntax
                         $openingTag .
                         $name .
                         $parameters .
-                        '\s*' .
+                        $optionalWhitespace .
                         $closingTagMarker .
                         $closingTag .
                         '|' .

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -56,6 +56,22 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[  sc arg=val cmp="a b"/]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
             array('[  sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
             array('[  sc x="\ "   /]', 'sc', array('x' => '\ '), null),
+
+            //check for whitespace after opening tag
+            array('[sc  ]', 'sc', array(), null),
+            array('[sc arg=val  ]', 'sc', array('arg' => 'val'), null),
+            array('[sc novalue arg="complex value"  ]', 'sc', array('novalue' => null, 'arg' => 'complex value'), null),
+            array('[sc x="ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ"  ]', 'sc', array('x' => 'ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ'), null),
+            array('[sc x="multi'."\n".'line"  ]', 'sc', array('x' => 'multi'."\n".'line'), null),
+            array('[sc noval x="val" y  ]content[/sc  ]', 'sc', array('noval'=> null, 'x' => 'val', 'y' => null), 'content'),
+            array('[sc x="{..}"  ]', 'sc', array('x' => '{..}'), null),
+            array('[sc a="x y" b="x" c=""  ]', 'sc', array('a' => 'x y', 'b' => 'x', 'c' => ''), null),
+            array('[sc a="a \"\" b"  ]', 'sc', array('a' => 'a \"\" b'), null),
+            array('[sc/  ]', 'sc', array(), null),
+            array('[sc    /  ]', 'sc', array(), null),
+            array('[sc arg=val cmp="a b"/  ]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
+            array('[sc x y   /  ]', 'sc', array('x' => null, 'y' => null), null),
+            array('[sc x="\ "   /  ]', 'sc', array('x' => '\ '), null),
             );
         }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -40,6 +40,22 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[sc arg=val cmp="a b"/]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
             array('[sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
             array('[sc x="\ "   /]', 'sc', array('x' => '\ '), null),
+
+            //check for whitespace after opening tag
+            array('[  sc]', 'sc', array(), null),
+            array('[  sc arg=val]', 'sc', array('arg' => 'val'), null),
+            array('[  sc novalue arg="complex value"]', 'sc', array('novalue' => null, 'arg' => 'complex value'), null),
+            array('[  sc x="ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ"]', 'sc', array('x' => 'ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ'), null),
+            array('[  sc x="multi'."\n".'line"]', 'sc', array('x' => 'multi'."\n".'line'), null),
+            array('[  sc noval x="val" y]content[/sc]', 'sc', array('noval'=> null, 'x' => 'val', 'y' => null), 'content'),
+            array('[  sc x="{..}"]', 'sc', array('x' => '{..}'), null),
+            array('[  sc a="x y" b="x" c=""]', 'sc', array('a' => 'x y', 'b' => 'x', 'c' => ''), null),
+            array('[  sc a="a \"\" b"]', 'sc', array('a' => 'a \"\" b'), null),
+            array('[  sc/]', 'sc', array(), null),
+            array('[  sc    /]', 'sc', array(), null),
+            array('[  sc arg=val cmp="a b"/]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
+            array('[  sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
+            array('[  sc x="\ "   /]', 'sc', array('x' => '\ '), null),
             );
         }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -41,7 +41,7 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
             array('[sc x="\ "   /]', 'sc', array('x' => '\ '), null),
 
-            //check for whitespace after opening tag
+            //check for whitespace after opening tag  (start data set 15)
             array('[  sc]', 'sc', array(), null),
             array('[  sc arg=val]', 'sc', array('arg' => 'val'), null),
             array('[  sc novalue arg="complex value"]', 'sc', array('novalue' => null, 'arg' => 'complex value'), null),
@@ -57,7 +57,7 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[  sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
             array('[  sc x="\ "   /]', 'sc', array('x' => '\ '), null),
 
-            //check for whitespace after opening tag
+            //check for whitespace before closing tag (start data set 29)
             array('[sc  ]', 'sc', array(), null),
             array('[sc arg=val  ]', 'sc', array('arg' => 'val'), null),
             array('[sc novalue arg="complex value"  ]', 'sc', array('novalue' => null, 'arg' => 'complex value'), null),
@@ -72,6 +72,34 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[sc arg=val cmp="a b"/  ]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
             array('[sc x y   /  ]', 'sc', array('x' => null, 'y' => null), null),
             array('[sc x="\ "   /  ]', 'sc', array('x' => '\ '), null),
+
+            //check for whitespace surrounding equals (start data set 43)
+            array('[sc arg  =  val]', 'sc', array('arg' => 'val'), null),
+            array('[sc novalue arg  =  "complex value"]', 'sc', array('novalue' => null, 'arg' => 'complex value'), null),
+            array('[sc x  =  "ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ"]', 'sc', array('x' => 'ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ'), null),
+            array('[sc x  =  "multi'."\n".'line"]', 'sc', array('x' => 'multi'."\n".'line'), null),
+            array('[sc noval x  =  "val" y]content[/sc]', 'sc', array('noval'=> null, 'x' => 'val', 'y' => null), 'content'),
+            array('[sc x  =  "{..}"]', 'sc', array('x' => '{..}'), null),
+            array('[sc a  =  "x y" b  =  "x" c=  ""]', 'sc', array('a' => 'x y', 'b' => 'x', 'c' => ''), null),
+            array('[sc a  =  "a \"\" b"]', 'sc', array('a' => 'a \"\" b'), null),
+            array('[sc arg  =  val cmp  =  "a b"/]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
+            array('[sc x  =  "\ "   /]', 'sc', array('x' => '\ '), null),
+
+            //check for spaces everywhere (start data set 53)
+            array('[  sc  ]', 'sc', array(), null),
+            array('[sc arg  =  val  ]', 'sc', array('arg' => 'val'), null),
+            array('[sc   novalue   arg  =  "complex value"  ]', 'sc', array('novalue' => null, 'arg' => 'complex value'), null),
+            array('[sc x  =  "ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ"  ]', 'sc', array('x' => 'ąćęłńóśżź ĄĆĘŁŃÓŚŻŹ'), null),
+            array('[sc x  =  "multi'."\n".'line"  ]', 'sc', array('x' => 'multi'."\n".'line'), null),
+            array('[sc noval x  =  "val" y  ]content[  /sc  ]', 'sc', array('noval'=> null, 'x' => 'val', 'y' => null), 'content'),
+            array('[sc x  =  "{..}"  ]', 'sc', array('x' => '{..}'), null),
+            array('[sc a  =  "x y" b  =  "x" c  =  ""  ]', 'sc', array('a' => 'x y', 'b' => 'x', 'c' => ''), null),
+            array('[sc a  =  "a \"\" b"  ]', 'sc', array('a' => 'a \"\" b'), null),
+            array('[sc/  ]', 'sc', array(), null),
+            array('[sc    /  ]', 'sc', array(), null),
+            array('[sc arg  =  val cmp  =  "a b"/  ]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
+            array('[sc x y   /  ]', 'sc', array('x' => null, 'y' => null), null),
+            array('[sc x  =  "\ "   /  ]', 'sc', array('x' => '\ '), null),
             );
         }
 

--- a/tests/SyntaxTest.php
+++ b/tests/SyntaxTest.php
@@ -57,4 +57,42 @@ final class SyntaxTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('==', $syntax->getParameterValueSeparator());
         $this->assertSame('""', $syntax->getParameterValueDelimiter());
         }
+
+    /**
+     * @dataProvider getDataForSpacesTrimmedCorrectly
+     */
+    public function testSpacesTrimmedCorrectly($incoming, $expected)
+        {
+            $propertiesToTest = array(
+
+                'OpeningTag',
+                'ClosingTag',
+                'ClosingTagMarker',
+                'ParameterValueSeparator',
+                'ParameterValueDelimiter'
+            );
+
+            foreach ($propertiesToTest as $property) {
+
+                $getter = "get$property";
+                $setter = "set$property";
+
+                $builder = new SyntaxBuilder();
+                $syntax = $builder->$setter($incoming)->getSyntax();
+                $this->assertEquals($expected, $syntax->$getter());
+            }
+        }
+
+    public function getDataForSpacesTrimmedCorrectly()
+        {
+            return array(
+
+                array('  x  ', 'x'),
+                array('x  ', 'x'),
+                array('  x', 'x'),
+                array("\tx\t", 'x'),
+                array("x\t", 'x'),
+                array("\tx", 'x'),
+            );
+        }
     }


### PR DESCRIPTION
This PR introduces whitespace tolerance, meaning the following types of shortcodes will now parse correctly:
- `[  sc  ]`
- `[sc/    ]`
- `[sc arg  =  val  ]`
- `[sc x y   /  ]`
- `[     sc a  =  "x y" b  =  "x" c  =  ""     ]`

... along with many other variations (see updated `ParserTest.php`). It doesn't touch anything inside the parameter value delimiter, of course, so with

`[ sc foo = " bar "  / ]`

the value of `foo` would be `bar` (spaces included). I also did two other things in these commits, which you may or may not want to merge:
1. Continued to expand the regex construction. For me this makes it significantly easier to see what's going on, and I feel will make future changes to the regex a little more clear.
2. Introduced regex caching in `Syntax.php` for a small/cheap performance gain when processing shortcodes with the same syntax multiple times.
