### PR TITLE
Whitespace tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,20 +169,22 @@ var_dump($shortcode);
 ```
 **Syntax**
 
-Both `Parser` and `Extractor` classes provide configurable shortcode syntax capabilities which can be achieved by passing `Syntax` object as their first argument:
+Both `Parser` and `Extractor` classes provide configurable shortcode syntax capabilities which can be achieved by passing `Syntax` object as their first argument. There are two syntax variants: liberal that allows extra whitespace (for example `[  code  arg  = val]content[ / code  ]`) and strict which requires no extra whitespace between shortcode fragments (like in the examples at the beginning of this README).
 
 ```php
 use Thunder\Shortcode\Syntax;
 use Thunder\Shortcode\SyntaxBuilder;
 
-// these two are equivalent, builder is more verbose
-$syntax = new Syntax('[[', ']]', '//', '==', '""');
+// all of these are equivalent, builder is more verbose
+$syntax = Syntax::create('[[', ']]', '//', '==', '""');
+$syntax = Syntax::createStrict('[[', ']]', '//', '==', '""');
 $syntax = (new SyntaxBuilder())
     ->setOpeningTag('[[')
     ->setClosingTag(']]')
     ->setClosingTagMarker('//')
     ->setParameterValueSeparator('==')
     ->setParameterValueDelimiter('""')
+    ->setStrict(true) // if true then strict syntax will be created
     ->getSyntax();
 
 // create both objects as usual, if nothing is passed defaults are assumed

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -49,19 +49,17 @@ final class Parser implements ParserInterface
 
     private function parseValue($value)
         {
-        return $this->isStringValue(trim($value))
-            ? $this->extractStringValue(trim($value))
-            : (null === $value ? null : trim($value));
+        return null === $value ? null : $this->extractValue(trim($value));
         }
 
-    private function extractStringValue($value)
+    private function extractValue($value)
         {
         $length = strlen($this->syntax->getParameterValueDelimiter());
 
-        return substr($value, $length, -1 * $length);
+        return $this->isDelimitedValue($value) ? substr($value, $length, -1 * $length) : $value;
         }
 
-    private function isStringValue($value)
+    private function isDelimitedValue($value)
         {
         return preg_match('/^'.$this->syntax->getParameterValueDelimiter().'/us', $value)
             && preg_match('/'.$this->syntax->getParameterValueDelimiter().'$/us', $value);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -25,7 +25,7 @@ final class Parser implements ParserInterface
             }
 
         return new Shortcode(
-            isset($matches[4]) ? $matches[4] : $matches[2],
+            trim(isset($matches[4]) ? $matches[4] : $matches[2]),
             isset($matches[5])
                 ? $this->parseParameters($matches[5])
                 : (isset($matches[3]) ? $this->parseParameters($matches[3]) : array()),
@@ -41,7 +41,7 @@ final class Parser implements ParserInterface
         foreach($argsMatches[1] as $item)
             {
             $parts = explode($this->syntax->getParameterValueSeparator(), $item, 2);
-            $return[$parts[0]] = $this->parseValue(isset($parts[1]) ? $parts[1] : null);
+            $return[trim($parts[0])] = $this->parseValue(isset($parts[1]) ? $parts[1] : null);
             }
 
         return $return;
@@ -49,9 +49,9 @@ final class Parser implements ParserInterface
 
     private function parseValue($value)
         {
-        return $this->isStringValue($value)
-            ? $this->extractStringValue($value)
-            : $value;
+        return $this->isStringValue(trim($value))
+            ? $this->extractStringValue(trim($value))
+            : (null === $value ? null : trim($value));
         }
 
     private function extractStringValue($value)

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -54,11 +54,11 @@ final class Syntax
         // lookahead test for either space or end of string
         $empty = '(?=\s|$)';
         // equals sign and alphanumeric value
-        $simple = $equals.'\w+';
+        $simple = '\s*'.$equals.'\s*\w+';
         // equals sign and value without unescaped string delimiters enclosed in them
-        $complex = $equals.$string.'([^'.$string.'\\\\]*(?:\\\\.[^'.$string.'\\\\]*)*?)'.$string;
+        $complex = '\s*'.$equals.'\s*'.$string.'([^'.$string.'\\\\]*(?:\\\\.[^'.$string.'\\\\]*)*?)'.$string;
 
-        $this->argumentsRegex = '~(?:\s+(\w+(?:'.$empty.'|'.$simple.'|'.$complex.')))~us';
+        $this->argumentsRegex = '~(?:\s*(\w+(?:'.$simple.'|'.$complex.'|'.$empty.')))~us';
         }
 
     private function createShortcodeRegexContent()
@@ -68,14 +68,14 @@ final class Syntax
         $close = $this->quote($this->getClosingTag());
 
         // alphanumeric characters and dash
-        $name = '([\w-]+)';
+        $name = '(\s*[\w-]+)';
         // any characters that are not closing tag marker
         $parameters = '(\s+[^'.$slash.']+?)?';
         // non-greedy match for any characters
         $content = '(.*?)';
 
         // open tag, name, parameters, maybe some spaces, closing marker, closing tag
-        $selfClosed  = $open.$name.$parameters.'\s*'.$slash.$close;
+        $selfClosed  = $open.$name.$parameters.'\s*'.$slash.'\s*'.$close;
         // open tag, name, parameters, closing tag, maybe some content and closing
         // block with backreference name validation
         $withContent = $open.$name.$parameters.$close.'(?:'.$content.$open.$slash.'(\4)'.$close.')?';

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -12,6 +12,10 @@ final class Syntax
     private $parameterValueSeparator;
     private $parameterValueDelimiter;
 
+    private $shortcodeRegex;
+    private $singleShortcodeRegex;
+    private $argumentsRegex;
+
     public function __construct($openingTag = null, $closingTag = null, $closingTagMarker = null,
                                 $parameterValueSeparator = null, $parameterValueDelimiter = null)
         {
@@ -20,19 +24,29 @@ final class Syntax
         $this->closingTagMarker = $closingTagMarker ?: '/';
         $this->parameterValueSeparator = $parameterValueSeparator ?: '=';
         $this->parameterValueDelimiter = $parameterValueDelimiter ?: '"';
+
+        $shortcodeRegex = $this->createShortcodeRegexContent();
+        $this->shortcodeRegex = '~'.$shortcodeRegex.'~us';
+        $this->singleShortcodeRegex = '~^'.$shortcodeRegex.'$~us';
+        $this->createArgumentsRegex();
         }
 
     public function getShortcodeRegex()
         {
-        return '~'.$this->createShortcodeRegex().'~us';
+        return $this->shortcodeRegex;
         }
 
     public function getSingleShortcodeRegex()
         {
-        return '~^'.$this->createShortcodeRegex().'$~us';
+        return $this->singleShortcodeRegex;
         }
 
     public function getArgumentsRegex()
+        {
+        return $this->argumentsRegex;
+        }
+
+    private function createArgumentsRegex()
         {
         $equals = $this->quote($this->getParameterValueSeparator());
         $string = $this->quote($this->getParameterValueDelimiter());
@@ -44,10 +58,10 @@ final class Syntax
         // equals sign and value without unescaped string delimiters enclosed in them
         $complex = $equals.$string.'([^'.$string.'\\\\]*(?:\\\\.[^'.$string.'\\\\]*)*?)'.$string;
 
-        return '~(?:\s+(\w+(?:'.$empty.'|'.$simple.'|'.$complex.')))~us';
+        $this->argumentsRegex = '~(?:\s+(\w+(?:'.$empty.'|'.$simple.'|'.$complex.')))~us';
         }
 
-    private function createShortcodeRegex()
+    private function createShortcodeRegexContent()
         {
         $open = $this->quote($this->getOpeningTag());
         $slash = $this->quote($this->getClosingTagMarker());

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -68,7 +68,7 @@ final class Syntax
         $close = $this->quote($this->getClosingTag());
 
         // alphanumeric characters and dash
-        $name = '(\s*[\w-]+)';
+        $name = '\s*([\w-]+)';
         // any characters that are not closing tag marker
         $parameters = '(\s+[^'.$slash.']+?)?';
         // non-greedy match for any characters
@@ -78,7 +78,8 @@ final class Syntax
         $selfClosed  = $open.$name.$parameters.'\s*'.$slash.'\s*'.$close;
         // open tag, name, parameters, closing tag, maybe some content and closing
         // block with backreference name validation
-        $withContent = $open.$name.$parameters.$close.'(?:'.$content.$open.$slash.'(\4)'.$close.')?';
+        $closingTag = $open.'\s*'.$slash.'\s*(\4)\s*'.$close;
+        $withContent = $open.$name.$parameters.'\s*'.$close.'(?:'.$content.$closingTag.')?';
 
         return '((?:'.$selfClosed.'|'.$withContent.'))';
         }

--- a/src/SyntaxBuilder.php
+++ b/src/SyntaxBuilder.php
@@ -11,6 +11,7 @@ final class SyntaxBuilder
     private $closingTagMarker;
     private $parameterValueSeparator;
     private $parameterValueDelimiter;
+    private $isStrict = false;
 
     public function __construct()
         {
@@ -18,10 +19,18 @@ final class SyntaxBuilder
 
     public function getSyntax()
         {
-        return new Syntax(
-            $this->openingTag, $this->closingTag, $this->closingTagMarker,
-            $this->parameterValueSeparator, $this->parameterValueDelimiter
-            );
+        $args = array($this->openingTag, $this->closingTag, $this->closingTagMarker,
+            $this->parameterValueSeparator, $this->parameterValueDelimiter);
+        $method = $this->isStrict ? 'createStrict' : 'create';
+
+        return call_user_func_array(array('Thunder\Shortcode\Syntax', $method), $args);
+        }
+
+    public function setStrict($isStrict)
+        {
+        $this->isStrict = (bool)$isStrict;
+
+        return $this;
         }
 
     public function setOpeningTag($tag)

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -60,6 +60,11 @@ final class ExtractorTest extends \PHPUnit_Framework_TestCase
                 new Match(21, '[code cmp="xx"/]'),
                 new Match(40, '[code x=y/]'),
                 )),
+            array('x [    code arg=val /]a[ code/]c[x    /    ]', array(
+                new Match(2, '[    code arg=val /]'),
+                new Match(23, '[ code/]'),
+                new Match(32, '[x    /    ]'),
+                )),
             );
         }
 

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -60,10 +60,11 @@ final class ExtractorTest extends \PHPUnit_Framework_TestCase
                 new Match(21, '[code cmp="xx"/]'),
                 new Match(40, '[code x=y/]'),
                 )),
-            array('x [    code arg=val /]a[ code/]c[x    /    ]', array(
+            array('x [    code arg=val /]a[ code/]c[x    /    ] m [ y ] c [   /   y]', array(
                 new Match(2, '[    code arg=val /]'),
                 new Match(23, '[ code/]'),
                 new Match(32, '[x    /    ]'),
+                new Match(47, '[ y ] c [   /   y]'),
                 )),
             );
         }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -40,6 +40,8 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[sc arg=val cmp="a b"/]', 'sc', array('arg' => 'val', 'cmp' => 'a b'), null),
             array('[sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
             array('[sc x="\ "   /]', 'sc', array('x' => '\ '), null),
+            array('[   sc   x =  "\ "   y =   value  z   /    ]', 'sc', array('x' => '\ ', 'y' => 'value', 'z' => null), null),
+            array('[   sc   x=  "\ "   y    =value  z    ]', 'sc', array('x' => '\ ', 'y' => 'value', 'z' => null), null),
             );
         }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -41,7 +41,7 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             array('[sc x y   /]', 'sc', array('x' => null, 'y' => null), null),
             array('[sc x="\ "   /]', 'sc', array('x' => '\ '), null),
             array('[   sc   x =  "\ "   y =   value  z   /    ]', 'sc', array('x' => '\ ', 'y' => 'value', 'z' => null), null),
-            array('[   sc   x=  "\ "   y    =value  z    ]', 'sc', array('x' => '\ ', 'y' => 'value', 'z' => null), null),
+            array('[ sc   x=  "\ "   y    =value   ] vv [ /  sc  ]', 'sc', array('x' => '\ ', 'y' => 'value'), ' vv '),
             );
         }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -45,6 +45,21 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
             );
         }
 
+    public function testParserWithStrictSyntax()
+        {
+        $parser = new Parser(Syntax::createStrict());
+
+        $provided = $this->provideShortcodes();
+        $shortcode = $parser->parse($provided[0][0]);
+
+        $this->assertSame($provided[0][1], $shortcode->getName());
+        $this->assertSame($provided[0][2], $shortcode->getParameters());
+        $this->assertSame($provided[0][3], $shortcode->getContent());
+
+        $this->setExpectedException('RuntimeException');
+        $parser->parse($provided[16][0]);
+        }
+
     /**
      * @dataProvider provideInvalid
      */

--- a/tests/SyntaxTest.php
+++ b/tests/SyntaxTest.php
@@ -20,6 +20,17 @@ final class SyntaxTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('"', $syntax->getParameterValueDelimiter());
         }
 
+    public function testSyntaxWithNamedConstructor()
+        {
+        $syntax = Syntax::create();
+
+        $this->assertSame('[', $syntax->getOpeningTag());
+        $this->assertSame(']', $syntax->getClosingTag());
+        $this->assertSame('/', $syntax->getClosingTagMarker());
+        $this->assertSame('=', $syntax->getParameterValueSeparator());
+        $this->assertSame('"', $syntax->getParameterValueDelimiter());
+        }
+
     public function testCustomSyntax()
         {
         $syntax = new Syntax('[[', ']]', '//', '==', '""');

--- a/tests/SyntaxTest.php
+++ b/tests/SyntaxTest.php
@@ -60,6 +60,7 @@ final class SyntaxTest extends \PHPUnit_Framework_TestCase
             ->setClosingTagMarker('//')
             ->setParameterValueSeparator('==')
             ->setParameterValueDelimiter('""')
+            ->setStrict(true)
             ->getSyntax();
 
         $this->assertSame('[[', $syntax->getOpeningTag());


### PR DESCRIPTION
This is a reimplemented version of @ehough's "whitespace tolerance" PR #6. He chose to withdraw his contribution, but the whole idea and implementation credits go to him:
- [x] whitespace between shortcode fragments are now accepted by default, which means that codes like `[   code  arg    =  val x val=    "value"   ] x [    /    code  ]` are now possible,
- [x] introduced named constructors `Syntax::create()` and `Syntax::createStrict()`. The latter is to support previous "strict" syntax that does not allow whitespaces,
- [x] regular expressions inside `Syntax` class are now generated once on class instantiation,
- [x] documentation for the points above.
