### PR TITLE
Skip processing handler if this is not a valid shortcode

### DIFF
--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -64,6 +64,9 @@ final class Processor implements ProcessorInterface
         foreach ($shortcodes as $shortcode) {
             $this->prepareHandlerContext($shortcode, $context);
             $handler = $this->handlers->get($shortcode->getName());
+            if (is_null($handler)) {
+                continue;
+            }
             $replace = $this->processHandler($shortcode, $context, $handler);
             $length = mb_strlen($shortcode->getText());
 


### PR DESCRIPTION
I was getting some very strange content corruption when I enabled my shortcode plugin that uses your fantastic little shortcode library. This was caused by my having some square bracketed content that did not match up with any of my defined shortcode handlers:

```
##### html([title][, alt][, classes])

!! In Markdown this method is implicitly called when using the `![]` syntax.

The `html` action will output a valid HTML tag for the media based on the current display mode.
```

This `[title]`, `[, alt]` and `[, classes]` text is used in my documentation to display optional method params.  However, it was corrupting that title to something like:

```
<h5>html([t[title] alt][, classes])</h5>
```

I debugged this in the Shortcode library and discovered that you were first collecting all the potential shortcodes in the entire page (quite a lot for me), and then iterating over them.  However, when you retrieved the handler for every shortcode, it would continue to try to process the shortcode even if the handler was null.  This ultimately leads to all kinds of corruption of the end content.

Simply checking to see if this handler is null, and then continuing without doing any more processing ensures there is no corruption, and also speeds up the page parsing considerably.

FYI - I created a core shortcode plugin for Grav CMS, and a subsequent shortcode plugin that adds some UI specific shortcodes in case you are interested.
- https://getgrav.org
- https://github.com/getgrav/grav-plugin-shortcode-core
- https://github.com/getgrav/grav-plugin-shortcode-ui
