### PR TITLE
Regular parser performance improvements

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -159,6 +159,12 @@ final class ParserTest extends \PHPUnit_Framework_TestCase
                 new ParsedShortcode(new Shortcode('sc', array(), null), '[sc]', 4),
                 new ParsedShortcode(new Shortcode('sc', array(), null), '[sc]', 10),
             )),
+
+            // performance
+//            array($s, 'x [[aa]] y', array()),
+            array($s, str_repeat('[a]', 20), array_map(function($offset) { // 20
+                return new ParsedShortcode(new Shortcode('a', array(), null), '[a]', $offset);
+            }, range(0, 57, 3))),
         );
 
         /**


### PR DESCRIPTION
As discussed with @rhukster in #26 and #27 there are massive performance problems in `RegularParser` when trying to parse big documents. This PR provides significant improvements for parsing speed while maintaining the correctness this parser was built for. Blackfire reports -91% performance improvement on "small" example and "full" completes in about 3.5s (which is at least 4500% improvement since it was reported that it didn't complete in more than half an hour).
