### PR TITLE
Dropped PHP 5.3 and added PHP 7.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
   - nightly
 


### PR DESCRIPTION
Travis dropped active support for build running on Ubuntu Precise and this means that PHP 5.3 is not available anymore. This version is 8 years old now and really should not be used anywhere, so I'm dropping it from build matrix. You can still install Shortcode on PHP 5.3 and it will work, but I think PHP 5.x versions are to be dropped in the future.