### PR TITLE
Fixed invalid opening or closing token sequence causing wrong shortcode content.

### DIFF
--- a/src/Parser/RegularParser.php
+++ b/src/Parser/RegularParser.php
@@ -124,7 +124,12 @@ final class RegularParser implements ParserInterface
 
         while($this->position < $this->tokensCount) {
             while($this->position < $this->tokensCount && false === $this->lookahead(self::TOKEN_OPEN)) {
-                $this->match(null, $appendContent);
+                $this->match(null, $appendContent, true);
+            }
+            $isShortcode = $this->lookaheadN(array(self::TOKEN_OPEN, self::TOKEN_STRING));
+            $isCloser = $this->lookaheadN(array(self::TOKEN_OPEN, self::TOKEN_MARKER));
+            if(false === ($isShortcode || $isCloser)) {
+                $this->match(null, $appendContent, true);
                 continue;
             }
 
@@ -253,6 +258,25 @@ final class RegularParser implements ParserInterface
         }
 
         return implode('', array_map(function(array $token) { return $token[1]; }, $tokens));
+    }
+
+    private function lookaheadN(array $types)
+    {
+        $position = $this->position;
+        foreach($types as $type) {
+            if($position >= $this->tokensCount) {
+                return false;
+            }
+            if($this->tokens[$position][0] === self::TOKEN_WS) {
+                $position++;
+            }
+            if($this->tokens[$position][0] !== $type) {
+                return false;
+            }
+            $position++;
+        }
+
+        return true;
     }
 
     private function lookahead($type, $callback = null)

--- a/src/Parser/RegularParser.php
+++ b/src/Parser/RegularParser.php
@@ -258,27 +258,31 @@ final class RegularParser implements ParserInterface
         return $this->position < $this->tokensCount && (empty($type) || $this->tokens[$this->position][0] === $type);
     }
 
-    private function match($type, $callbacks = null, $ws = false)
+    private function match($type, $callback = null, $ws = false)
     {
         if($this->position >= $this->tokensCount) {
             return false;
         }
 
-        $type = (array)$type;
         $token = $this->tokens[$this->position];
-        if(!empty($type) && !in_array($token[0], $type)) {
+        if(!empty($type) && $token[0] !== $type) {
             return false;
         }
         foreach($this->backtracks as &$backtrack) {
             $backtrack[] = $token;
         }
+        unset($backtrack);
 
+        $callback && $callback($token);
         $this->position++;
-        foreach((array)$callbacks as $callback) {
-            $callback($token);
-        }
 
-        $ws && $this->match(self::TOKEN_WS);
+        if($ws && $this->position < $this->tokensCount && $this->tokens[$this->position][0] === self::TOKEN_WS) {
+            $token = $this->tokens[$this->position];
+            $this->position++;
+            foreach($this->backtracks as &$backtrack) {
+                $backtrack[] = $token;
+            }
+        }
 
         return true;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -213,9 +213,10 @@ final class ParserTest extends AbstractTestCase
             array($s, '[x=#F00 one=#F00 two="#F00"]', array(
                 new ParsedShortcode(new Shortcode('x', array('one' => '#F00', 'two' => '#F00'), null, '#F00'), '[x=#F00 one=#F00 two="#F00"]', 0),
             )),
-            array($s, '[ [] ] [x] [ ] [/x] ] [] [ [y] ] [] [ [z] [] [/z] [ [] ] [/y] ]', array(
+            array($s, '[ [] ] [x] [ ] [/x] ] [] [ [y] ] [] [ [z] [/#] [/z] [ [] ] [/] [/y] ] [z] [ [/ [/] /] ] [/z]', array(
                 new ParsedShortcode(new Shortcode('x', array(), ' [ ] ', null), '[x] [ ] [/x]', 7),
-                new ParsedShortcode(new Shortcode('y', array(), ' ] [] [ [z] [] [/z] [ [] ] ', null), '[y] ] [] [ [z] [] [/z] [ [] ] [/y]', 27),
+                new ParsedShortcode(new Shortcode('y', array(), ' ] [] [ [z] [/#] [/z] [ [] ] [/] ', null), '[y] ] [] [ [z] [/#] [/z] [ [] ] [/] [/y]', 27),
+                new ParsedShortcode(new Shortcode('z', array(), ' [ [/ [/] /] ] ', null), '[z] [ [/ [/] /] ] [/z]', 70),
             )),
         );
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -213,6 +213,10 @@ final class ParserTest extends AbstractTestCase
             array($s, '[x=#F00 one=#F00 two="#F00"]', array(
                 new ParsedShortcode(new Shortcode('x', array('one' => '#F00', 'two' => '#F00'), null, '#F00'), '[x=#F00 one=#F00 two="#F00"]', 0),
             )),
+            array($s, '[ [] ] [x] [ ] [/x] ] [] [ [y] ] [] [ [z] [] [/z] [ [] ] [/y] ]', array(
+                new ParsedShortcode(new Shortcode('x', array(), ' [ ] ', null), '[x] [ ] [/x]', 7),
+                new ParsedShortcode(new Shortcode('y', array(), ' ] [] [ [z] [] [/z] [ [] ] ', null), '[y] ] [] [ [z] [] [/z] [ [] ] [/y]', 27),
+            )),
         );
 
         /**


### PR DESCRIPTION
Fixes reported issue #58. When shortcode content contains invalid shortcode opening or closing tag, RegularParser reports just-closed shortcode instead of correctly computing its content. Fixed by adding further lookaheads before calling `::shortcode()` or `::close()` while in `::content()` method.