### PR TITLE
RegularParser block tokens

### DIFF
--- a/src/Parser/RegularParser.php
+++ b/src/Parser/RegularParser.php
@@ -314,18 +314,28 @@ final class RegularParser implements ParserInterface
 
     private function getTokenizerRegex(SyntaxInterface $syntax)
     {
-        $quote = function($text, $group) {
+        $group = function($text, $group) {
             return '(?<'.$group.'>'.preg_replace('/(.)/us', '\\\\$0', $text).')';
+        };
+        $quote = function($text) {
+            return preg_replace('/(.)/us', '\\\\$0', $text);
         };
 
         $rules = array(
-            $quote($syntax->getOpeningTag(), 'open'),
-            $quote($syntax->getClosingTag(), 'close'),
-            $quote($syntax->getClosingTagMarker(), 'marker'),
-            $quote($syntax->getParameterValueSeparator(), 'separator'),
-            $quote($syntax->getParameterValueDelimiter(), 'delimiter'),
+            $group($syntax->getOpeningTag(), 'open'),
+            $group($syntax->getClosingTag(), 'close'),
+            $group($syntax->getClosingTagMarker(), 'marker'),
+            $group($syntax->getParameterValueSeparator(), 'separator'),
+            $group($syntax->getParameterValueDelimiter(), 'delimiter'),
             '(?<ws>\s+)',
-            '(?<string>[\w-]+|\\\\.|.)',
+            '(?<string>\\\\.|(?:(?!'.implode('|', array(
+                $quote($syntax->getOpeningTag()),
+                $quote($syntax->getClosingTag()),
+                $quote($syntax->getClosingTagMarker()),
+                $quote($syntax->getParameterValueSeparator()),
+                $quote($syntax->getParameterValueDelimiter()),
+                '\s+',
+            )).').)+)',
         );
 
         return '~('.implode('|', $rules).')~us';


### PR DESCRIPTION
Tokenizer in RegularParser broke down the text into single characters or words (with some exceptions) regardless of the token type. This PR improves the tokenizer regex to report the text fragments without syntax tokens as single string tokens which should improve performance and reduce idle string joining operations in the parsing process, especially in real-world use cases with long texts with few shortcodes inside.