### PR TITLE
RegularParser improvements

### DIFF
--- a/src/Parser/RegularParser.php
+++ b/src/Parser/RegularParser.php
@@ -43,6 +43,7 @@ final class RegularParser implements ParserInterface
      */
     public function parse($text)
     {
+        $nestingLevel = ini_set('xdebug.max_nesting_level', -1);
         $this->tokens = $this->tokenize($text);
         $this->backtracks = array();
         $this->lastBacktrack = 0;
@@ -63,6 +64,7 @@ final class RegularParser implements ParserInterface
                 }
             }
         }
+        ini_set('xdebug.max_nesting_level', $nestingLevel);
 
         return $shortcodes;
     }

--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -106,7 +106,6 @@ final class Processor implements ProcessorInterface
 
             $replaces[] = new ReplacedShortcode($shortcode, $replace);
         }
-        $replaces = array_filter($replaces);
 
         $applyEvent = new ReplaceShortcodesEvent($text, $replaces, $parent);
         $this->dispatchEvent(Events::REPLACE_SHORTCODES, $applyEvent);
@@ -116,13 +115,16 @@ final class Processor implements ProcessorInterface
 
     private function applyReplaces($text, array $replaces)
     {
-        return array_reduce(array_reverse($replaces), function($state, ReplacedShortcode $s) {
+        /** @var ReplacedShortcode $s */
+        foreach(array_reverse($replaces) as $s) {
             $offset = $s->getOffset();
             $length = mb_strlen($s->getText(), 'utf-8');
-            $textLength = mb_strlen($state, 'utf-8');
+            $textLength = mb_strlen($text, 'utf-8');
 
-            return mb_substr($state, 0, $offset, 'utf-8').$s->getReplacement().mb_substr($state, $offset + $length, $textLength, 'utf-8');
-        }, $text);
+            $text = mb_substr($text, 0, $offset, 'utf-8').$s->getReplacement().mb_substr($text, $offset + $length, $textLength, 'utf-8');
+        }
+
+        return $text;
     }
 
     private function processHandler(ParsedShortcodeInterface $parsed, ProcessorContext $context, $handler)


### PR DESCRIPTION
Results are based on Blackfire runs of test data provided in #71. Current master finishes in 12.5s and uses 514MiBs of memory.

- [x] improved lexer regex generator, now non-token input parts are reported as a single token instead of per-character matches. Blackfire reports ~8s and 337MiB respectively,
- [x] backtracks now rely on their offsets only instead of per-backtrack token storage. Blackfire reports over 143x performance gain, ~85ms and ~9MiB respectively,
- [x] during verification phase I accidentally replicated #70 and to fix it I needed to greatly simplify the lexer regex and switch the token comparison method from named capture groups to string comparison, which ate a significant part of the performance gains mentioned above. Still, the final result is 850ms and ~47MiB. Not as good as I hoped, but I'm still happy with the result,
- [x] inlined `RegularParser::content()` body inside `RegularParser::shortcode()` which halves the nesting level requirement causing problems in #71,
- [x] there is no way of detecting the current nesting level and safely manipulating its value to avoid the `\Error` being thrown in the middle of parsing process, therefore I'm disabling the `xdebug.max_nesting_level` setting it to `-1` and restoring its value afterwards. AFAIK PHP does not have the nesting level limit, it's strictly XDebug mechanism and the error is reproducible **only** when XDebug is enabled with its default `256` nesting limit. Disabling XDebug or increasing the nesting limit (test data required 1024, 512 after inlining `content()`).
- [x] lexer was reverted to named capture groups, for some reason slightly reordered alternations do not cause memory limit errors anymore.

That's my kind of well spent Saturday afternoon (and Sunday).