### PR TITLE
Quality improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - hhvm
   - nightly
 
@@ -24,5 +26,7 @@ after_script:
 
 matrix:
   allow_failures:
+    - php: 5.3
+    - php: hhvm
     - php: nightly
     - php: hhvm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHP ?= 7.2
+PHP ?= 7.3
 
 composer-update:
 	docker-compose run --rm composer composer config platform.php ${PHP}
@@ -8,3 +8,6 @@ composer-update:
 test:
 	docker-compose run --rm php-${PHP} php -v
 	docker-compose run --rm php-${PHP} php /app/vendor/bin/phpunit -c /app/phpunit.xml.dist
+test-local:
+	php -v
+	php vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+PHP ?= 7.2
+
+composer-update:
+	docker-compose run --rm composer composer config platform.php ${PHP}
+	docker-compose run --rm composer composer update
+	docker-compose run --rm composer composer config --unset platform
+
+test:
+	docker-compose run --rm php-${PHP} php -v
+	docker-compose run --rm php-${PHP} php /app/vendor/bin/phpunit -c /app/phpunit.xml.dist

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     image: 'composer:1.6'
     volumes: ['.:/app']
 
-  # FIXME: PHP 5.3 contains neither mbstring extension nor docker-php-ext-install script
+  # PHP 5.3 contains neither mbstring extension nor docker-php-ext-install script
   # Original Dockerfile can be found here https://github.com/docker-library/php/pull/20/files
   # Unfortunately it fails to build now because GPG signatures do not exist anymore
   # php-5.3: { build: 'docker/php-5.3', volumes: ['.:/app'] }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+
+  composer:
+    image: 'composer:1.6'
+    volumes: ['.:/app']
+
+  # FIXME: PHP 5.3 contains neither mbstring extension nor docker-php-ext-install script
+  # Original Dockerfile can be found here https://github.com/docker-library/php/pull/20/files
+  # Unfortunately it fails to build now because GPG signatures do not exist anymore
+  # php-5.3: { build: 'docker/php-5.3', volumes: ['.:/app'] }
+  php-5.4: { build: 'docker/php-5.4', volumes: ['.:/app'] }
+  php-5.5: { image: 'php:5.5', volumes: ['.:/app'] }
+  php-5.6: { image: 'php:5.6', volumes: ['.:/app'] }
+  php-7.0: { image: 'php:7.0', volumes: ['.:/app'] }
+  php-7.1: { image: 'php:7.1', volumes: ['.:/app'] }
+  php-7.2: { image: 'php:7.2', volumes: ['.:/app'] }
+  php-7.3: { image: 'php:7.3', volumes: ['.:/app'] }

--- a/docker/php-5.4/Dockerfile
+++ b/docker/php-5.4/Dockerfile
@@ -1,0 +1,3 @@
+FROM php:5.4
+
+RUN docker-php-ext-install mbstring

--- a/src/Event/ReplaceShortcodesEvent.php
+++ b/src/Event/ReplaceShortcodesEvent.php
@@ -23,7 +23,6 @@ class ReplaceShortcodesEvent
     {
         $this->shortcode = $shortcode;
         $this->text = $text;
-        $this->result = null;
 
         $this->setReplacements($replacements);
     }

--- a/src/EventContainer/EventContainer.php
+++ b/src/EventContainer/EventContainer.php
@@ -16,7 +16,7 @@ final class EventContainer implements EventContainerInterface
 
     public function addListener($event, $handler)
     {
-        if(!in_array($event, Events::getEvents())) {
+        if(!\in_array($event, Events::getEvents(), true)) {
             throw new \InvalidArgumentException(sprintf('Unsupported event %s!', $event));
         }
 

--- a/src/EventHandler/FilterRawEventHandler.php
+++ b/src/EventHandler/FilterRawEventHandler.php
@@ -25,7 +25,7 @@ final class FilterRawEventHandler
     public function __invoke(FilterShortcodesEvent $event)
     {
         $parent = $event->getParent();
-        if($parent && in_array($parent->getName(), $this->names)) {
+        if($parent && \in_array($parent->getName(), $this->names, true)) {
             $event->setShortcodes(array());
 
             return;

--- a/src/HandlerContainer/HandlerContainer.php
+++ b/src/HandlerContainer/HandlerContainer.php
@@ -62,7 +62,7 @@ final class HandlerContainer implements HandlerContainerInterface
 
     public function get($name)
     {
-        return $this->has($name) ? $this->handlers[$name] : ($this->default ?: null);
+        return $this->has($name) ? $this->handlers[$name] : $this->default;
     }
 
     public function has($name)

--- a/src/Parser/WordpressParser.php
+++ b/src/Parser/WordpressParser.php
@@ -97,7 +97,7 @@ final class WordpressParser implements ParserInterface
                 $parameters[strtolower($match[3])] = stripcslashes($match[4]);
             } elseif(!empty($match[5])) {
                 $parameters[strtolower($match[5])] = stripcslashes($match[6]);
-            } elseif(isset($match[7]) && strlen($match[7])) {
+            } elseif(isset($match[7]) && $match[7] !== '') {
                 $parameters[stripcslashes($match[7])] = null;
             } elseif(isset($match[8])) {
                 $parameters[stripcslashes($match[8])] = null;

--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -23,7 +23,8 @@ final class Processor implements ProcessorInterface
     /** @var EventContainerInterface */
     private $eventContainer;
 
-    private $recursionDepth = null; // infinite recursion
+    /** @var int|null */
+    private $recursionDepth; // infinite recursion
     private $maxIterations = 1; // one iteration
     private $autoProcessContent = true; // automatically process shortcode content
 
@@ -144,7 +145,7 @@ final class Processor implements ProcessorInterface
         return mb_substr($state, 0, $offset, 'utf-8').$processed->getContent().mb_substr($state, $offset + $length, mb_strlen($state, 'utf-8'), 'utf-8');
     }
 
-    private function processRecursion(ParsedShortcodeInterface $shortcode, ProcessorContext $context)
+    private function processRecursion(ProcessedShortcode $shortcode, ProcessorContext $context)
     {
         if ($this->autoProcessContent && null !== $shortcode->getContent()) {
             $context->recursionLevel++;

--- a/src/Processor/ProcessorContext.php
+++ b/src/Processor/ProcessorContext.php
@@ -9,21 +9,21 @@ use Thunder\Shortcode\Shortcode\ShortcodeInterface;
 final class ProcessorContext
 {
     /** @var ShortcodeInterface */
-    public $shortcode = null;
+    public $shortcode;
 
     /** @var ShortcodeInterface */
-    public $parent = null;
+    public $parent;
 
     /** @var ProcessorInterface */
-    public $processor = null;
+    public $processor;
 
-    public $textContent = null;
+    public $textContent;
     public $position = 0;
     public $namePosition = array();
     public $text = '';
     public $shortcodeText = '';
     public $iterationNumber = 0;
     public $recursionLevel = 0;
-    public $offset = null;
-    public $baseOffset = null;
+    public $offset;
+    public $baseOffset;
 }

--- a/src/Serializer/TextSerializer.php
+++ b/src/Serializer/TextSerializer.php
@@ -56,7 +56,7 @@ final class TextSerializer implements SerializerInterface
         $delimiter = $this->syntax->getParameterValueDelimiter();
         $separator = $this->syntax->getParameterValueSeparator();
 
-        return $separator.(preg_match('/^\w+$/us', $value)
+        return $separator.(preg_match('/^\w+$/u', $value)
             ? $value
             : $delimiter.$value.$delimiter);
     }

--- a/src/Shortcode/Shortcode.php
+++ b/src/Shortcode/Shortcode.php
@@ -8,11 +8,11 @@ final class Shortcode extends AbstractShortcode implements ShortcodeInterface
 {
     public function __construct($name, array $parameters, $content, $bbCode = null)
     {
-        if(false === is_string($name) || (is_string($name) && !\mb_strlen($name))) {
+        if(false === is_string($name) || '' === $name) {
             throw new \InvalidArgumentException('Shortcode name must be a non-empty string!');
         }
 
-        $isStringOrNull = function($value) { return is_string($value) || is_null($value); };
+        $isStringOrNull = function($value) { return is_string($value) || null === $value; };
         if(count(array_filter($parameters, $isStringOrNull)) !== count($parameters)) {
             throw new \InvalidArgumentException('Parameter values must be either string or empty (null)!');
         }

--- a/src/Shortcode/Shortcode.php
+++ b/src/Shortcode/Shortcode.php
@@ -8,7 +8,7 @@ final class Shortcode extends AbstractShortcode implements ShortcodeInterface
 {
     public function __construct($name, array $parameters, $content, $bbCode = null)
     {
-        if(false === is_string($name) || (is_string($name) && !mb_strlen($name))) {
+        if(false === is_string($name) || (is_string($name) && !\mb_strlen($name))) {
             throw new \InvalidArgumentException('Shortcode name must be a non-empty string!');
         }
 


### PR DESCRIPTION
- [x] added PHP 7.3 to Travis matrix,
- [x] added support for PHPUnit 7.x,
- [x] added `docker-compose` with PHP from 5.4 up to 7.3 (custom 5.4 image, 5.3 lacks `ext-mbstring`),
- [x] added Makefile with `composer update` and `phpunit` commands based on `docker-compose`,
- [x] added `hirak/prestissimo` for faster dependency installation,
- [x] resolved the issue with `expectException()` on PHP 7.3,
- [x] minor code cleanup: removed property null assignments, less function calls, strict comparison,
- [x] fixed PHPUnit 7.x `phpunit.xml` issues.