### PR TITLE
Faulty parameter value empties previous shortcodes

### DIFF
--- a/.symfony.insight.yaml
+++ b/.symfony.insight.yaml
@@ -1,0 +1,4 @@
+rules:
+  # RegularParser::parse() disables xdebug.max_nesting_level to avoid errors when XDebug is enabled
+  php.dynamically_change_configuration:
+    enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ after_script:
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,22 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.1|^5.0|^6.0",
-        "symfony/yaml": "^2.0|^3.0"
+        "phpunit/phpunit": ">=4.1",
+        "symfony/yaml": ">=2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Thunder\\Shortcode\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Thunder\\Shortcode\\Tests\\": "tests/"
+        }
     },
     "suggest": {
         "symfony/yaml": "if you want to use YAML serializer",
         "ext-dom": "if you want to use XML serializer",
         "ext-json": "if you want to use JSON serializer"
-    },
-    "autoload": {
-        "psr-4": {
-            "Thunder\\Shortcode\\": "src/",
-            "Thunder\\Shortcode\\Tests\\": "tests/"
-        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
     convertWarningsToExceptions = "true"
     processIsolation = "false"
     stopOnFailure = "false"
-    syntaxCheck = "false"
     bootstrap = "vendor/autoload.php"
     >
 
@@ -19,8 +18,7 @@
     </testsuites>
 
     <logging>
-        <log type="coverage-html" target="coverage" charset="UTF-8"
-             yui="true" highlight="false" lowUpperBound="50" highLowerBound="90"/>
+        <log type="coverage-html" target="coverage" lowUpperBound="50" highLowerBound="90"/>
         <log type="coverage-clover" target="coverage.xml"/>
     </logging>
 

--- a/src/Parser/RegularParser.php
+++ b/src/Parser/RegularParser.php
@@ -57,6 +57,11 @@ final class RegularParser implements ParserInterface
             $names = array();
             $this->beginBacktrack();
             $matches = $this->shortcode($names);
+            if(false === $matches) {
+                $this->backtrack();
+                $this->match(null, true);
+                continue;
+            }
             if(\is_array($matches)) {
                 foreach($matches as $shortcode) {
                     $shortcodes[] = $shortcode;
@@ -151,11 +156,13 @@ final class RegularParser implements ParserInterface
         if(false === $content || $closingName !== $name) {
             $this->backtrack(false);
             $text = $this->backtrack(false);
+            array_pop($names);
 
             return array_merge(array($this->getObject($name, $parameters, $bbCode, $offset, null, $text)), $shortcodes);
         }
         $content = $this->getBacktrack();
         if(!$this->close($names)) { return false; }
+        array_pop($names);
 
         return array($this->getObject($name, $parameters, $bbCode, $offset, $content, $this->getBacktrack()));
     }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -8,10 +8,10 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class AbstractTestCase extends TestCase
 {
-    public function expectException($exception)
+    public function willThrowException($exception)
     {
         version_compare(phpversion(), '7.0.0') > 0
-            ? parent::expectException($exception)
+            ? $this->expectException($exception)
             : $this->setExpectedException($exception);
     }
 }

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -79,19 +79,19 @@ final class EventsTest extends AbstractTestCase
     public function testExceptionOnHandlerForUnknownEvent()
     {
         $events = new EventContainer();
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         $events->addListener('invalid', function() {});
     }
 
     public function testInvalidFilterRawShortcodesNames()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         new FilterRawEventHandler(array(new \stdClass()));
     }
 
     public function testInvalidReplaceJoinNames()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         new ReplaceJoinEventHandler(array(new \stdClass()));
     }
 }

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -84,14 +84,14 @@ EOF;
 
     public function testInvalidSerializationFormatException()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         $facade = new ShortcodeFacade();
         $facade->serialize(new Shortcode('name', array(), null), 'invalid');
     }
 
     public function testInvalidUnserializationFormatException()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         $facade = new ShortcodeFacade();
         $facade->unserialize('[c]', 'invalid');
     }

--- a/tests/HandlerContainerTest.php
+++ b/tests/HandlerContainerTest.php
@@ -14,7 +14,7 @@ final class HandlerContainerTest extends AbstractTestCase
     {
         $handlers = new HandlerContainer();
         $handlers->add('name', function () {});
-        $this->expectException('RuntimeException');
+        $this->willThrowException('RuntimeException');
         $handlers->add('name', function () {});
     }
 
@@ -31,7 +31,7 @@ final class HandlerContainerTest extends AbstractTestCase
     public function testRemoveException()
     {
         $handlers = new HandlerContainer();
-        $this->expectException('RuntimeException');
+        $this->willThrowException('RuntimeException');
         $handlers->remove('code');
     }
 
@@ -59,7 +59,7 @@ final class HandlerContainerTest extends AbstractTestCase
     public function testInvalidHandler()
     {
         $handlers = new HandlerContainer();
-        $this->expectException('RuntimeException');
+        $this->willThrowException('RuntimeException');
         $handlers->add('invalid', new \stdClass());
     }
 
@@ -75,7 +75,7 @@ final class HandlerContainerTest extends AbstractTestCase
     public function testExceptionIfAliasingNonExistentHandler()
     {
         $handlers = new HandlerContainer();
-        $this->expectException('RuntimeException');
+        $this->willThrowException('RuntimeException');
         $handlers->addAlias('m', 'missing');
     }
 

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -267,21 +267,21 @@ final class ProcessorTest extends AbstractTestCase
     public function testExceptionOnInvalidRecursionDepth()
     {
         $processor = new Processor(new RegularParser(), new HandlerContainer());
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         $processor->withRecursionDepth(new \stdClass());
     }
 
     public function testExceptionOnInvalidMaxIterations()
     {
         $processor = new Processor(new RegularParser(), new HandlerContainer());
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         $processor->withMaxIterations(new \stdClass());
     }
 
     public function testExceptionOnInvalidAutoProcessFlag()
     {
         $processor = new Processor(new RegularParser(), new HandlerContainer());
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         $processor->withAutoProcessContent(new \stdClass());
     }
 

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -91,7 +91,7 @@ final class SerializerTest extends AbstractTestCase
      */
     public function testSerializerExceptions(SerializerInterface $serializer, $value, $exceptionClass)
     {
-        $this->expectException($exceptionClass);
+        $this->willThrowException($exceptionClass);
         $serializer->unserialize($value);
     }
 

--- a/tests/ShortcodeTest.php
+++ b/tests/ShortcodeTest.php
@@ -131,7 +131,7 @@ final class ShortcodeTest extends AbstractTestCase
 
     public function testShortcodeEmptyNameException()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->willThrowException('InvalidArgumentException');
         new Shortcode('', array(), null);
     }
 }


### PR DESCRIPTION
Fixes #77.

- [x] added Symfony Insight configuration file disabling the dynamic configuration error from `RegularParser`,
- [x] moved HHVM to allowed failures as it has diverged from PHP and won't work anymore,
- [x] fixed PHPUnit >7.x configuration errors,
- [x] added custom `willThrowException()` assertion wrapping recent changes in PHPUnit.