### PR TITLE
Fix for PHP 7.4 error

### DIFF
--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -140,7 +140,7 @@ final class Processor implements ProcessorInterface
 
         $state = $parsed->getText();
         $length = mb_strlen($processed->getTextContent(), 'utf-8');
-        $offset = mb_strrpos($state, $processed->getTextContent(), 'utf-8');
+        $offset = mb_strrpos($state, $processed->getTextContent(), 0, 'utf-8');
 
         return mb_substr($state, 0, $offset, 'utf-8').$processed->getContent().mb_substr($state, $offset + $length, mb_strlen($state, 'utf-8'), 'utf-8');
     }


### PR DESCRIPTION
After testing Grav with PHP 7.4 this weekend, I was getting an error from `Processor.php`

<img width="1287" alt="Image 2019-12-02 at 9 32 18 AM" src="https://user-images.githubusercontent.com/1084697/69976750-bb8f8480-14e6-11ea-9a25-3e09ad288795.png">

To pass an encoding, you must also pass an offset.  0 is default.

https://www.php.net/manual/en/function.mb-strrpos.php