### PR TITLE
PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 php:
@@ -9,6 +10,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - hhvm
   - nightly
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHP ?= 7.3
+PHP ?= 7.4
 
 composer-update:
 	docker-compose run --rm composer composer config platform.php ${PHP}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,3 +17,4 @@ services:
   php-7.1: { image: 'php:7.1', volumes: ['.:/app'] }
   php-7.2: { image: 'php:7.2', volumes: ['.:/app'] }
   php-7.3: { image: 'php:7.3', volumes: ['.:/app'] }
+  php-7.4: { image: 'php:7.4', volumes: ['.:/app'] }

--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -140,7 +140,7 @@ final class Processor implements ProcessorInterface
 
         $state = $parsed->getText();
         $length = mb_strlen($processed->getTextContent(), 'utf-8');
-        $offset = mb_strrpos($state, $processed->getTextContent(), 'utf-8');
+        $offset = mb_strrpos($state, $processed->getTextContent(), 0, 'utf-8');
 
         return mb_substr($state, 0, $offset, 'utf-8').$processed->getContent().mb_substr($state, $offset + $length, mb_strlen($state, 'utf-8'), 'utf-8');
     }


### PR DESCRIPTION
- [x] Travis matrix includes `7.4snapshot`,
- [x] Travis distribution remains on `trusty` to support PHP 5.4 and 5.5,
- [x] fixed PHP 7.4 deprecation of `mb_strrpos()` [3rd parameter](https://wiki.php.net/rfc/deprecations_php_7_4) (#81, #82),
- [x] Makefile and `docker-compose` include local 7.4 version.

@rhukster we can merge your PR, but then the build will fail - this PR includes your fix along with CI changes which make everything as green as it was before. Please let me know what do you think, I'm ready to merge this one right away and tag a new release.