### PR TITLE
Updating getParameter docblock

### DIFF
--- a/src/Shortcode/ShortcodeInterface.php
+++ b/src/Shortcode/ShortcodeInterface.php
@@ -34,7 +34,7 @@ interface ShortcodeInterface
      * without value
      *
      * @param string $name Parameter name
-     * @param null $default Value returned if there is no parameter with given name
+     * @param mixed $default Value returned if there is no parameter with given name
      *
      * @return mixed
      */

--- a/src/Shortcode/ShortcodeInterface.php
+++ b/src/Shortcode/ShortcodeInterface.php
@@ -34,9 +34,9 @@ interface ShortcodeInterface
      * without value
      *
      * @param string $name Parameter name
-     * @param mixed $default Value returned if there is no parameter with given name
+     * @param string|null $default Value returned if there is no parameter with given name
      *
-     * @return mixed
+     * @return string|null
      */
     public function getParameter($name, $default = null);
 


### PR DESCRIPTION
Current `@param` value of `null` results in a PhanTypeMismatchArgument error when analyzing code that implements the interface with phan.

```
CollectionsShortcode.php:19 PhanTypeMismatchArgument Argument 2 ($default) is false but \Thunder\Shortcode\Shortcode\ShortcodeInterface::getParameter() takes null defined at vendor/thunderer/shortcode/src/Shortcode/ShortcodeInterface.php:41
```