### PR TITLE
Improve assertions

### DIFF
--- a/tests/ShortcodeTest.php
+++ b/tests/ShortcodeTest.php
@@ -84,7 +84,7 @@ final class ShortcodeTest extends AbstractTestCase
         static::assertSame('[code]', $processed->getShortcodeText());
         static::assertSame(1, $processed->getIterationNumber());
         static::assertSame(0, $processed->getRecursionLevel());
-        static::assertSame(null, $processed->getParent());
+        static::assertNull($processed->getParent());
         static::assertSame($processor, $processed->getProcessor());
     }
 


### PR DESCRIPTION
# Changed log

- Using the `assertNull` to assert expected is same as `null`.