### PR TITLE
Add setDefaultHandler method to ShortcodeFacade

### DIFF
--- a/src/ShortcodeFacade.php
+++ b/src/ShortcodeFacade.php
@@ -112,6 +112,19 @@ class ShortcodeFacade
     }
 
     /**
+     * @param callable $handler
+     * @psalm-param callable(ShortcodeInterface):string $handler
+     *
+     * @return $this
+     */
+    public function setDefaultHandler($handler)
+    {
+        $this->handlers->setDefault($handler);
+
+        return $this;
+    }
+
+    /**
      * @param string $name
      * @psalm-param callable(ShortcodeInterface):string $handler
      *


### PR DESCRIPTION
It seems there was no method available to set a default handler in ShortcodeFacade, so I added one.