### PR TITLE
parse shortcode parameters

### DIFF
--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -161,6 +161,14 @@ final class Processor implements ProcessorInterface
         $content = $this->processRecursion($processed, $context);
         $processed = $processed->withContent($content);
 
+        $parameters = $processed->getParameters();
+        foreach ($parameters as $key => $value) {
+            if (is_string($value)) {
+                $parameters[$key] = $this->process($value);
+            }
+        }
+        $processed = $processed->withParameters($parameters);
+
         if(null !== $handler) {
             return $handler($processed);
         }

--- a/src/Shortcode/ProcessedShortcode.php
+++ b/src/Shortcode/ProcessedShortcode.php
@@ -78,6 +78,19 @@ final class ProcessedShortcode extends AbstractShortcode implements ParsedShortc
     }
 
     /**
+     * @param array $parameters
+     *
+     * @return self
+     */
+    public function withParameters(array $parameters)
+    {
+        $clone = clone $this;
+        $clone->parameters = $parameters;
+
+        return $clone;
+    }
+
+    /**
      * @param string $name
      *
      * @return bool

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -89,7 +89,8 @@ final class ProcessorTest extends AbstractTestCase
             array('x [i /][i]i[/i][i /][i]i[/i][i /] z', 'x [i /][i]i[/i][i /][i]i[/i][i /] z'),
             array('x [url url="http://giggle.com/search" /] z', 'x <a href="http://giggle.com/search">http://giggle.com/search</a> z'),
             array('x [url="http://giggle.com/search"] z', 'x <a href="http://giggle.com/search">http://giggle.com/search</a> z'),
-            );
+            array('x [url url="http://giggle.com/[content]random[/content]"] z', 'x <a href="http://giggle.com/random">http://giggle.com/random</a> z'),
+        );
     }
 
     public function testProcessorParentContext()


### PR DESCRIPTION
In shortcode parameters we can have shortcode too (cf sample in  `ProcessorTest`)

Add feature to parse parameters in addition to the content